### PR TITLE
Implement the likes tab on others' profiles

### DIFF
--- a/src/js/dataLayer/dataStore.js
+++ b/src/js/dataLayer/dataStore.js
@@ -36,6 +36,7 @@ export class DataStore extends EventEmitter {
     this.profileFollowers = new Map();
     this.profileFollows = new Map();
     this.profileChatStatus = new Map();
+    this.pdsEndpoints = new Map();
   }
 
   hasCurrentUser() {
@@ -516,5 +517,13 @@ export class DataStore extends EventEmitter {
 
   clearProfileChatStatus(profileDid) {
     this.profileChatStatus.delete(profileDid);
+  }
+
+  getPdsEndpoint(did) {
+    return this.pdsEndpoints.get(did);
+  }
+
+  setPdsEndpoint(did, pdsEndpoint) {
+    this.pdsEndpoints.set(did, pdsEndpoint);
   }
 }


### PR DESCRIPTION
I noticed that Impro shows a "Likes" tab on every profile page, but it only works on the current user's profile. This change updates the feed fetching logic to support other users' likes, as follows:
- determine the user's PDS endpoint from their DID document
- request the like records from the user's PDS using `com.atproto.repo.listRecords`
- hydrate the posts using the existing `Api.getPosts` method

To avoid repeated requests to resolve the user's PDS endpoint, a DID-to-PDS mapping was added to `DataStore`.

Mostly implemented by Claude Opus 4.5 in Claude Code.