### PR TITLE
Support tangled.sh-hosted plugin repos

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -20,7 +20,7 @@ Your plugin should now appear in the "Community Plugins" page: `http://localhost
 
 ## Publishing a plugin
 
-To publish a plugin version, tag a commit with the version number (e.g. "0.1.0", no v) and push it to a public GitHub repository. To include your plugin in the Community Plugins listing, make a pull request to https://github.com/improsocial/impro-releases with the plugin info.
+To publish a plugin version, tag a commit with the version number (e.g. "0.1.0", no v) and push it to a public GitHub or Tangled repository. To include your plugin in the Community Plugins listing, make a pull request to https://github.com/improsocial/impro-releases with the plugin info.
 
 ## API surface
 

--- a/src/js/plugins/pluginCache.js
+++ b/src/js/plugins/pluginCache.js
@@ -8,13 +8,24 @@ export class PluginCache {
     return await caches.open(CACHE_NAME);
   }
 
-  async fetch(url, { doCacheNotFound = false } = {}) {
+  async fetch(
+    url,
+    { doCacheNotFound = false, isNotFound = (status) => status === 404 } = {},
+  ) {
     const cache = await this._getCache();
     let response = await cache.match(url);
     if (!response) {
       response = await fetch(url, { redirect: "follow" });
-      if (response.ok || (doCacheNotFound && response.status === 404)) {
+      if (response.ok) {
         await cache.put(url, response.clone());
+      } else if (doCacheNotFound) {
+        const body = await response
+          .clone()
+          .text()
+          .catch(() => null);
+        if (isNotFound(response.status, body)) {
+          await cache.put(url, response.clone());
+        }
       }
     }
     if (!response.ok) {

--- a/src/js/plugins/pluginCache.js
+++ b/src/js/plugins/pluginCache.js
@@ -20,6 +20,7 @@ export class PluginCache {
     if (!response.ok) {
       const error = new Error(`HTTP ${response.status} ${url}`);
       error.status = response.status;
+      error.body = await response.text().catch(() => null);
       throw error;
     }
     return response;

--- a/src/js/plugins/sourceProvider.js
+++ b/src/js/plugins/sourceProvider.js
@@ -39,14 +39,31 @@ export function repoWebUrl(repo) {
 }
 
 // GitHub's raw content host returns a clean 404 for a missing file.
-// tangled.sh's blob-fetch backend instead returns 500 with a JSON error
-// body ({"error":"InternalServerError","message":"failed to get blob"}) —
-// verified against a real repo, since it has no dedicated "not found"
-// status. Treat both as "file doesn't exist" for optional files
-// (styles.css, README.md) rather than a real fetch failure.
-function isMissingFileStatus(repo, status) {
+// tangled.sh's blob-fetch backend instead returns 500 with this exact JSON
+// error body for a missing blob — verified against a real repo, since it
+// has no dedicated "not found" status. Match on the body too (not just the
+// 500), so an actual tangled.sh outage still surfaces as a real error
+// instead of being silently swallowed as "file doesn't exist".
+function isTangledMissingBlobBody(body) {
+  if (typeof body !== "string") return false;
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return false;
+  }
+  return (
+    parsed?.error === "InternalServerError" &&
+    parsed?.message === "failed to get blob"
+  );
+}
+
+function isMissingFileStatus(repo, status, body) {
   if (status === 404) return true;
-  return parseRepoSpec(repo).host === "tangled" && status === 500;
+  if (status !== 500) return false;
+  return (
+    parseRepoSpec(repo).host === "tangled" && isTangledMissingBlobBody(body)
+  );
 }
 
 function remoteAssetUrl({ repo, file, release = null }) {
@@ -143,7 +160,7 @@ export class SourceProvider {
       });
       return await response.text();
     } catch (error) {
-      if (isMissingFileStatus(repo, error?.status)) return null;
+      if (isMissingFileStatus(repo, error?.status, error?.body)) return null;
       throw error;
     }
   }
@@ -161,9 +178,12 @@ export class SourceProvider {
     // Fetch from main branch so we show the latest README
     const url = remoteAssetUrl({ repo, file: "README.md" });
     const response = await fetch(url, { cache: "no-store" });
-    if (isMissingFileStatus(repo, response.status)) return null;
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    return await response.text();
+    const body = await response.text();
+    if (!response.ok) {
+      if (isMissingFileStatus(repo, response.status, body)) return null;
+      throw new Error(`HTTP ${response.status}`);
+    }
+    return body;
   }
 
   // URLs that should be retained in the cache

--- a/src/js/plugins/sourceProvider.js
+++ b/src/js/plugins/sourceProvider.js
@@ -15,9 +15,10 @@ function parsePluginManifest(pluginId, manifest) {
 }
 
 // A plugin listing's `repo` field is normally a bare "owner/repo" GitHub
-// path. It may also be prefixed with a host name ("host:owner/repo") to
-// source from somewhere else — currently just "tangled:" for tangled.sh
-// repos. GitHub owner/repo names can't contain ":", so this is unambiguous.
+// path. It may also be prefixed with a host name ("host:owner/repo"):
+// "github:" spells out the default explicitly, and "tangled:" sources from
+// tangled.sh. GitHub owner/repo names can't contain ":", so this is
+// unambiguous.
 export function parseRepoSpec(repo) {
   const colonIndex = repo.indexOf(":");
   if (colonIndex === -1) return { host: "github", path: repo };
@@ -58,11 +59,12 @@ function isTangledMissingBlobBody(body) {
   );
 }
 
-function isMissingFileStatus(repo, status, body) {
+function isMissingFileResponse(repo, status, body) {
   if (status === 404) return true;
-  if (status !== 500) return false;
   return (
-    parseRepoSpec(repo).host === "tangled" && isTangledMissingBlobBody(body)
+    parseRepoSpec(repo).host === "tangled" &&
+    status === 500 &&
+    isTangledMissingBlobBody(body)
   );
 }
 
@@ -75,7 +77,7 @@ function remoteAssetUrl({ repo, file, release = null }) {
     return `https://tangled.org/${path}/raw/${ref}/${file}`;
   }
   const ref = release ? `refs/tags/${release}` : "refs/heads/main";
-  return `https://raw.githubusercontent.com/${repo}/${ref}/${file}`;
+  return `https://raw.githubusercontent.com/${path}/${ref}/${file}`;
 }
 
 export class SourceProvider {
@@ -157,10 +159,11 @@ export class SourceProvider {
     try {
       const response = await this.pluginCache.fetch(url, {
         doCacheNotFound: true,
+        isNotFound: (status, body) => isMissingFileResponse(repo, status, body),
       });
       return await response.text();
     } catch (error) {
-      if (isMissingFileStatus(repo, error?.status, error?.body)) return null;
+      if (isMissingFileResponse(repo, error?.status, error?.body)) return null;
       throw error;
     }
   }
@@ -180,7 +183,7 @@ export class SourceProvider {
     const response = await fetch(url, { cache: "no-store" });
     const body = await response.text();
     if (!response.ok) {
-      if (isMissingFileStatus(repo, response.status, body)) return null;
+      if (isMissingFileResponse(repo, response.status, body)) return null;
       throw new Error(`HTTP ${response.status}`);
     }
     return body;

--- a/src/js/plugins/sourceProvider.js
+++ b/src/js/plugins/sourceProvider.js
@@ -38,6 +38,17 @@ export function repoWebUrl(repo) {
   return `https://github.com/${path}`;
 }
 
+// GitHub's raw content host returns a clean 404 for a missing file.
+// tangled.sh's blob-fetch backend instead returns 500 with a JSON error
+// body ({"error":"InternalServerError","message":"failed to get blob"}) —
+// verified against a real repo, since it has no dedicated "not found"
+// status. Treat both as "file doesn't exist" for optional files
+// (styles.css, README.md) rather than a real fetch failure.
+function isMissingFileStatus(repo, status) {
+  if (status === 404) return true;
+  return parseRepoSpec(repo).host === "tangled" && status === 500;
+}
+
 function remoteAssetUrl({ repo, file, release = null }) {
   const { host, path } = parseRepoSpec(repo);
   if (host === "tangled") {
@@ -132,7 +143,7 @@ export class SourceProvider {
       });
       return await response.text();
     } catch (error) {
-      if (error?.status === 404) return null;
+      if (isMissingFileStatus(repo, error?.status)) return null;
       throw error;
     }
   }
@@ -150,7 +161,7 @@ export class SourceProvider {
     // Fetch from main branch so we show the latest README
     const url = remoteAssetUrl({ repo, file: "README.md" });
     const response = await fetch(url, { cache: "no-store" });
-    if (response.status === 404) return null;
+    if (isMissingFileStatus(repo, response.status)) return null;
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     return await response.text();
   }

--- a/src/js/plugins/sourceProvider.js
+++ b/src/js/plugins/sourceProvider.js
@@ -14,7 +14,38 @@ function parsePluginManifest(pluginId, manifest) {
   return manifest;
 }
 
+// A plugin listing's `repo` field is normally a bare "owner/repo" GitHub
+// path. It may also be prefixed with a host name ("host:owner/repo") to
+// source from somewhere else — currently just "tangled:" for tangled.sh
+// repos. GitHub owner/repo names can't contain ":", so this is unambiguous.
+export function parseRepoSpec(repo) {
+  const colonIndex = repo.indexOf(":");
+  if (colonIndex === -1) return { host: "github", path: repo };
+  const host = repo.slice(0, colonIndex);
+  const path = repo.slice(colonIndex + 1);
+  if (host !== "github" && host !== "tangled") {
+    throw new Error(`Unsupported plugin repo host "${host}"`);
+  }
+  return { host, path };
+}
+
+// The human-facing "view source" URL for a plugin's repo field.
+export function repoWebUrl(repo) {
+  const { host, path } = parseRepoSpec(repo);
+  if (host === "tangled") {
+    return `https://tangled.org/${path}`;
+  }
+  return `https://github.com/${path}`;
+}
+
 function remoteAssetUrl({ repo, file, release = null }) {
+  const { host, path } = parseRepoSpec(repo);
+  if (host === "tangled") {
+    // tangled.sh serves raw blobs at /raw/<ref>/<path> for both branches
+    // and tags; there's no separate "refs/tags/..." form like GitHub's.
+    const ref = release ?? "main";
+    return `https://tangled.org/${path}/raw/${ref}/${file}`;
+  }
   const ref = release ? `refs/tags/${release}` : "refs/heads/main";
   return `https://raw.githubusercontent.com/${repo}/${ref}/${file}`;
 }

--- a/src/js/views/communityPluginListing.view.js
+++ b/src/js/views/communityPluginListing.view.js
@@ -7,6 +7,7 @@ import { showToast } from "/js/toasts.js";
 import { confirmModal } from "/js/modals/confirm.modal.js";
 import { Signal, ReactiveStore } from "/js/signals.js";
 import { PermissionsDeclinedError } from "/js/plugins/pluginService.js";
+import { repoWebUrl } from "/js/plugins/sourceProvider.js";
 import "/js/components/rendered-markdown.js";
 import "/js/components/context-menu.js";
 import "/js/components/context-menu-item.js";
@@ -225,11 +226,11 @@ class CommunityPluginListingView extends View {
                       ? html`<div class="plugin-listing-repo">
                           Repository:
                           <a
-                            href="https://github.com/${listing.repo}"
+                            href="${repoWebUrl(listing.repo)}"
                             target="_blank"
                             rel="noopener noreferrer"
                             data-external
-                            >https://github.com/${listing.repo}</a
+                            >${repoWebUrl(listing.repo)}</a
                           >
                         </div>`
                       : ""}

--- a/tests/unit/specs/plugins/pluginCache.test.js
+++ b/tests/unit/specs/plugins/pluginCache.test.js
@@ -145,7 +145,27 @@ describe("PluginCache.fetch", () => {
     assert.deepEqual(fetchStub.calls.length, 1);
   });
 
-  it("does not cache non-404 errors even with doCacheNotFound", async () => {
+  it("caches errors a custom isNotFound predicate matches on the body", async () => {
+    fetchStub = stubFetch(async () =>
+      makeResponse("failed to get blob", { ok: false, status: 500 }),
+    );
+    const cache = new PluginCache();
+    const url = "https://example.test/styles.css";
+    const options = {
+      doCacheNotFound: true,
+      isNotFound: (status, body) =>
+        status === 500 && body === "failed to get blob",
+    };
+    const error = await cache
+      .fetch(url, options)
+      .then(null, (thrown) => thrown);
+    assert.deepEqual(error.status, 500);
+    assert.deepEqual(error.body, "failed to get blob");
+    await assert.rejects(cache.fetch(url, options), /500/);
+    assert.deepEqual(fetchStub.calls.length, 1);
+  });
+
+  it("does not cache non-404 errors with the default isNotFound", async () => {
     fetchStub = stubFetch(async () =>
       makeResponse("boom", { ok: false, status: 500 }),
     );
@@ -153,6 +173,23 @@ describe("PluginCache.fetch", () => {
     const url = "https://example.test/styles.css";
     await assert.rejects(cache.fetch(url, { doCacheNotFound: true }), /500/);
     await assert.rejects(cache.fetch(url, { doCacheNotFound: true }), /500/);
+    assert.deepEqual(fetchStub.calls.length, 2);
+  });
+
+  it("does not cache not-found responses without doCacheNotFound", async () => {
+    fetchStub = stubFetch(async () =>
+      makeResponse("nope", { ok: false, status: 404 }),
+    );
+    const cache = new PluginCache();
+    const url = "https://example.test/styles.css";
+    await assert.rejects(
+      cache.fetch(url, { isNotFound: (status) => status === 404 }),
+      /404/,
+    );
+    await assert.rejects(
+      cache.fetch(url, { isNotFound: (status) => status === 404 }),
+      /404/,
+    );
     assert.deepEqual(fetchStub.calls.length, 2);
   });
 

--- a/tests/unit/specs/plugins/pluginCache.test.js
+++ b/tests/unit/specs/plugins/pluginCache.test.js
@@ -155,6 +155,27 @@ describe("PluginCache.fetch", () => {
     await assert.rejects(cache.fetch(url, { doCacheNotFound: true }), /500/);
     assert.deepEqual(fetchStub.calls.length, 2);
   });
+
+  it("attaches the response body text to errors on non-OK responses", async () => {
+    fetchStub = stubFetch(async () =>
+      makeResponse(
+        '{"error":"InternalServerError","message":"failed to get blob"}',
+        {
+          ok: false,
+          status: 500,
+        },
+      ),
+    );
+    const cache = new PluginCache();
+    const error = await cache
+      .fetch("https://example.test/styles.css")
+      .then(null, (thrown) => thrown);
+    assert.deepEqual(error.status, 500);
+    assert.deepEqual(
+      error.body,
+      '{"error":"InternalServerError","message":"failed to get blob"}',
+    );
+  });
 });
 
 describe("PluginCache.reconcile", () => {

--- a/tests/unit/specs/sourceProvider.test.js
+++ b/tests/unit/specs/sourceProvider.test.js
@@ -375,4 +375,48 @@ describe("SourceProvider with tangled.sh-hosted plugins", () => {
     }
     assert(caught?.message.includes('Unsupported plugin repo host "gitlab"'));
   });
+
+  // tangled.sh's blob backend returns 500 (not 404) for a missing file, so
+  // "optional file absent" detection has to special-case it per host.
+  it("getStyles treats a tangled 500 as a missing styles.css, not an error", async () => {
+    const pluginCache = fakePluginCache(async () => {
+      const error = new Error("HTTP 500");
+      error.status = 500;
+      throw error;
+    });
+    const provider = new SourceProvider(pluginCache);
+    const styles = await provider.getStyles(
+      "alpha",
+      "1.0.0",
+      "tangled:ow/alpha",
+    );
+    assert.deepEqual(styles, null);
+  });
+
+  it("getStyles still throws a tangled 500 as an error for local plugins/other hosts", async () => {
+    const pluginCache = fakePluginCache(async () => {
+      const error = new Error("HTTP 500");
+      error.status = 500;
+      throw error;
+    });
+    const provider = new SourceProvider(pluginCache);
+    let caught = null;
+    try {
+      await provider.getStyles("alpha", "1.0.0", "ow/alpha");
+    } catch (error) {
+      caught = error;
+    }
+    assert.deepEqual(caught?.status, 500);
+  });
+
+  it("getReadme treats a tangled 500 as a missing README, not an error", async () => {
+    const stub = stubFetch(async () => ({ ok: false, status: 500 }));
+    try {
+      const provider = new SourceProvider(null);
+      const readme = await provider.getReadme("alpha", "tangled:ow/alpha");
+      assert.deepEqual(readme, null);
+    } finally {
+      stub.restore();
+    }
+  });
 });

--- a/tests/unit/specs/sourceProvider.test.js
+++ b/tests/unit/specs/sourceProvider.test.js
@@ -239,7 +239,10 @@ describe("SourceProvider with remote plugins", () => {
       pluginCache.calls[0].url,
       "https://raw.githubusercontent.com/ow/alpha/refs/tags/1.0.0/styles.css",
     );
-    assert.deepEqual(pluginCache.calls[0].options, { doCacheNotFound: true });
+    const { doCacheNotFound, isNotFound } = pluginCache.calls[0].options;
+    assert.deepEqual(doCacheNotFound, true);
+    assert.deepEqual(isNotFound(404, null), true);
+    assert.deepEqual(isNotFound(500, "boom"), false);
     assert.deepEqual(styles, "body{color:blue}");
   });
 
@@ -276,6 +279,37 @@ describe("SourceProvider with remote plugins", () => {
     } finally {
       stub.restore();
     }
+  });
+
+  it("accepts an explicit github: prefix on the repo", async () => {
+    const pluginCache = fakePluginCache(async () =>
+      jsonResponse({ id: "alpha", name: "A", version: "1.0.0" }),
+    );
+    const provider = new SourceProvider(pluginCache);
+    const manifest = await provider.getManifest(
+      "alpha",
+      "1.0.0",
+      "github:ow/alpha",
+    );
+    assert.deepEqual(
+      pluginCache.calls[0].url,
+      "https://raw.githubusercontent.com/ow/alpha/refs/tags/1.0.0/manifest.json",
+    );
+    assert.deepEqual(manifest.id, "alpha");
+  });
+
+  it("getCacheUrls strips the github: prefix from URLs", async () => {
+    const provider = new SourceProvider(null);
+    const urls = await provider.getCacheUrls(
+      "alpha",
+      "1.2.3",
+      "github:ow/alpha",
+    );
+    assert.deepEqual(urls, [
+      "https://raw.githubusercontent.com/ow/alpha/refs/tags/1.2.3/manifest.json",
+      "https://raw.githubusercontent.com/ow/alpha/refs/tags/1.2.3/main.js",
+      "https://raw.githubusercontent.com/ow/alpha/refs/tags/1.2.3/styles.css",
+    ]);
   });
 
   it("getStyles returns null when remote styles.css 404s", async () => {
@@ -397,6 +431,10 @@ describe("SourceProvider with tangled.sh-hosted plugins", () => {
       "tangled:ow/alpha",
     );
     assert.deepEqual(styles, null);
+    const { isNotFound } = pluginCache.calls[0].options;
+    assert.deepEqual(isNotFound(500, TANGLED_MISSING_BLOB_BODY), true);
+    assert.deepEqual(isNotFound(500, "boom"), false);
+    assert.deepEqual(isNotFound(404, null), true);
   });
 
   it("getStyles still throws a tangled 500 with an unrelated body", async () => {

--- a/tests/unit/specs/sourceProvider.test.js
+++ b/tests/unit/specs/sourceProvider.test.js
@@ -291,3 +291,88 @@ describe("SourceProvider with remote plugins", () => {
     assert.deepEqual(styles, null);
   });
 });
+
+describe("SourceProvider with tangled.sh-hosted plugins", () => {
+  it("fetches a versioned manifest from tangled.org via plugin cache", async () => {
+    const pluginCache = fakePluginCache(async () =>
+      jsonResponse({ id: "alpha", name: "A", version: "1.0.0" }),
+    );
+    const provider = new SourceProvider(pluginCache);
+    const manifest = await provider.getManifest(
+      "alpha",
+      "1.0.0",
+      "tangled:ow/alpha",
+    );
+    assert.deepEqual(
+      pluginCache.calls[0].url,
+      "https://tangled.org/ow/alpha/raw/1.0.0/manifest.json",
+    );
+    assert.deepEqual(manifest.id, "alpha");
+  });
+
+  it("fetches source from the version that was passed in", async () => {
+    const pluginCache = fakePluginCache(async () => ({
+      ok: true,
+      status: 200,
+      async text() {
+        return "alert(1)";
+      },
+    }));
+    const provider = new SourceProvider(pluginCache);
+    const source = await provider.getSource(
+      "alpha",
+      "2.5.0",
+      "tangled:ow/alpha",
+    );
+    assert.deepEqual(
+      pluginCache.calls[0].url,
+      "https://tangled.org/ow/alpha/raw/2.5.0/main.js",
+    );
+    assert.deepEqual(source, "alert(1)");
+  });
+
+  it("getLiveManifest fetches from the main branch", async () => {
+    const stub = stubFetch(async () =>
+      jsonResponse({ id: "alpha", name: "A", version: "9.9.9" }),
+    );
+    try {
+      const provider = new SourceProvider(null);
+      const manifest = await provider.getLiveManifest(
+        "alpha",
+        "tangled:ow/alpha",
+      );
+      assert.deepEqual(
+        stub.calls[0].url,
+        "https://tangled.org/ow/alpha/raw/main/manifest.json",
+      );
+      assert.deepEqual(manifest.version, "9.9.9");
+    } finally {
+      stub.restore();
+    }
+  });
+
+  it("getCacheUrls includes manifest, main.js, and styles.css URLs", async () => {
+    const provider = new SourceProvider(null);
+    const urls = await provider.getCacheUrls(
+      "alpha",
+      "1.2.3",
+      "tangled:ow/alpha",
+    );
+    assert.deepEqual(urls, [
+      "https://tangled.org/ow/alpha/raw/1.2.3/manifest.json",
+      "https://tangled.org/ow/alpha/raw/1.2.3/main.js",
+      "https://tangled.org/ow/alpha/raw/1.2.3/styles.css",
+    ]);
+  });
+
+  it("throws for an unrecognized repo host prefix", async () => {
+    const provider = new SourceProvider(fakePluginCache(async () => null));
+    let caught = null;
+    try {
+      await provider.getManifest("alpha", "1.0.0", "gitlab:ow/alpha");
+    } catch (error) {
+      caught = error;
+    }
+    assert(caught?.message.includes('Unsupported plugin repo host "gitlab"'));
+  });
+});

--- a/tests/unit/specs/sourceProvider.test.js
+++ b/tests/unit/specs/sourceProvider.test.js
@@ -378,10 +378,16 @@ describe("SourceProvider with tangled.sh-hosted plugins", () => {
 
   // tangled.sh's blob backend returns 500 (not 404) for a missing file, so
   // "optional file absent" detection has to special-case it per host.
-  it("getStyles treats a tangled 500 as a missing styles.css, not an error", async () => {
+  const TANGLED_MISSING_BLOB_BODY = JSON.stringify({
+    error: "InternalServerError",
+    message: "failed to get blob",
+  });
+
+  it("getStyles treats tangled's missing-blob 500 as a missing styles.css, not an error", async () => {
     const pluginCache = fakePluginCache(async () => {
       const error = new Error("HTTP 500");
       error.status = 500;
+      error.body = TANGLED_MISSING_BLOB_BODY;
       throw error;
     });
     const provider = new SourceProvider(pluginCache);
@@ -393,10 +399,45 @@ describe("SourceProvider with tangled.sh-hosted plugins", () => {
     assert.deepEqual(styles, null);
   });
 
-  it("getStyles still throws a tangled 500 as an error for local plugins/other hosts", async () => {
+  it("getStyles still throws a tangled 500 with an unrelated body", async () => {
     const pluginCache = fakePluginCache(async () => {
       const error = new Error("HTTP 500");
       error.status = 500;
+      error.body = JSON.stringify({ error: "InternalServerError" });
+      throw error;
+    });
+    const provider = new SourceProvider(pluginCache);
+    let caught = null;
+    try {
+      await provider.getStyles("alpha", "1.0.0", "tangled:ow/alpha");
+    } catch (error) {
+      caught = error;
+    }
+    assert.deepEqual(caught?.status, 500);
+  });
+
+  it("getStyles still throws a tangled 500 with a non-JSON body", async () => {
+    const pluginCache = fakePluginCache(async () => {
+      const error = new Error("HTTP 500");
+      error.status = 500;
+      error.body = "<html>gateway error</html>";
+      throw error;
+    });
+    const provider = new SourceProvider(pluginCache);
+    let caught = null;
+    try {
+      await provider.getStyles("alpha", "1.0.0", "tangled:ow/alpha");
+    } catch (error) {
+      caught = error;
+    }
+    assert.deepEqual(caught?.status, 500);
+  });
+
+  it("getStyles still throws a matching-body 500 for non-tangled repos", async () => {
+    const pluginCache = fakePluginCache(async () => {
+      const error = new Error("HTTP 500");
+      error.status = 500;
+      error.body = TANGLED_MISSING_BLOB_BODY;
       throw error;
     });
     const provider = new SourceProvider(pluginCache);
@@ -409,12 +450,32 @@ describe("SourceProvider with tangled.sh-hosted plugins", () => {
     assert.deepEqual(caught?.status, 500);
   });
 
-  it("getReadme treats a tangled 500 as a missing README, not an error", async () => {
-    const stub = stubFetch(async () => ({ ok: false, status: 500 }));
+  it("getReadme treats tangled's missing-blob 500 as a missing README, not an error", async () => {
+    const stub = stubFetch(async () =>
+      jsonResponse(TANGLED_MISSING_BLOB_BODY, { ok: false, status: 500 }),
+    );
     try {
       const provider = new SourceProvider(null);
       const readme = await provider.getReadme("alpha", "tangled:ow/alpha");
       assert.deepEqual(readme, null);
+    } finally {
+      stub.restore();
+    }
+  });
+
+  it("getReadme still throws a tangled 500 with an unrelated body", async () => {
+    const stub = stubFetch(async () =>
+      jsonResponse("server exploded", { ok: false, status: 500 }),
+    );
+    try {
+      const provider = new SourceProvider(null);
+      let caught = null;
+      try {
+        await provider.getReadme("alpha", "tangled:ow/alpha");
+      } catch (error) {
+        caught = error;
+      }
+      assert(caught?.message.includes("500"));
     } finally {
       stub.restore();
     }


### PR DESCRIPTION
A plugin listing's repo field was assumed to always be a bare "owner/repo" GitHub path (resolved against raw.githubusercontent.com), so a plugin hosted on tangled.sh had no way to be listed at all.

Prefixing the field with "tangled:" (e.g. "tangled:owner/repo") now routes manifest/source/styles/readme fetches through tangled.sh's /raw// endpoint instead, and the "view repository" link on the community plugin listing page resolves to the right host too. Unprefixed repo values keep resolving to GitHub exactly as before, so every existing community-plugins.json entry is unaffected.