### PR TITLE
Allow canvas's install script so it can be rebuilt against system libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
     "@capacitor/ios": "^7.0.0",
     "@capacitor/status-bar": "^7.0.0",
     "lit-html": "3.3.3"
+  },
+  "allowScripts": {
+    "canvas@3.2.3": true
   }
 }


### PR DESCRIPTION
Needed to build canvas from source (rather than using its prebuilt binary, which isn't ABI-compatible with nixpkgs' cairo/freetype) for local dev environments that gate npm install scripts.