### PR TITLE
Fix tangled cors via atproto

### DIFF
--- a/src/js/plugins/sourceProvider.js
+++ b/src/js/plugins/sourceProvider.js
@@ -107,14 +107,59 @@ function assertFontMagicBytes(file, bytes) {
 //   1. resolveIdentity(ownerHandle) -> owner DID + DID doc (handle
 //      resolver + plc.directory)
 //   2. getServiceEndpointFromDidDoc -> owner's PDS
-//   3. com.atproto.repo.getRecord on the owner's PDS for the repo's own
-//      "sh.tangled.repo" record (rkey = repo name) -> {knot, repoDid}
+//   3. the repo's own "sh.tangled.repo" record on the owner's PDS ->
+//      {knot, repoDid} (see findTangledRepoRecord below re. the two
+//      record-key schemes this has to handle)
 //   4. the individual knot server's own "sh.tangled.repo.blob" XRPC route
 //      (not the mirror), which does set Access-Control-Allow-Origin: *
 //
-// Cached per repo path since each resolution costs 3 network round-trips
-// and rarely changes.
+// Cached per repo path since each resolution costs multiple network
+// round-trips and rarely changes.
 const tangledRepoInfoCache = new Map();
+
+// The "sh.tangled.repo" record key scheme has changed at least once:
+// repos created more recently use the repo name directly as the record
+// key (rkey), while older repos use an opaque TID key instead, with the
+// repo name only present as an explicit "name" field on the record value
+// (confirmed against real accounts, e.g. tangled.org's own "infra" repo
+// still uses a TID key). Try the fast direct lookup first, and fall back
+// to scanning the owner's records by name — this has to keep working for
+// both existing schemes, and possibly future ones with the same fallback.
+async function findTangledRepoRecord(pds, ownerDid, repoName) {
+  const directUrl =
+    `${pds}/xrpc/com.atproto.repo.getRecord?` +
+    new URLSearchParams({
+      repo: ownerDid,
+      collection: "sh.tangled.repo",
+      rkey: repoName,
+    });
+  const directResponse = await fetch(directUrl);
+  if (directResponse.ok) {
+    const record = await directResponse.json();
+    if (record.value) return record.value;
+  }
+
+  let cursor = null;
+  for (let page = 0; page < 20; page++) {
+    const params = new URLSearchParams({
+      repo: ownerDid,
+      collection: "sh.tangled.repo",
+      limit: "100",
+    });
+    if (cursor) params.set("cursor", cursor);
+    const response = await fetch(
+      `${pds}/xrpc/com.atproto.repo.listRecords?${params}`,
+    );
+    if (!response.ok) return null;
+    const data = await response.json();
+    const records = data.records ?? [];
+    const match = records.find((record) => record.value?.name === repoName);
+    if (match) return match.value;
+    if (!data.cursor || records.length === 0) return null;
+    cursor = data.cursor;
+  }
+  return null;
+}
 
 async function resolveTangledRepoInfo(path) {
   if (tangledRepoInfoCache.has(path)) {
@@ -134,22 +179,13 @@ async function resolveTangledRepoInfo(path) {
     }
     const pds = getServiceEndpointFromDidDoc(identity.didDoc);
 
-    const recordUrl =
-      `${pds}/xrpc/com.atproto.repo.getRecord?` +
-      new URLSearchParams({
-        repo: identity.did,
-        collection: "sh.tangled.repo",
-        rkey: repoName,
-      });
-    const response = await fetch(recordUrl);
-    if (!response.ok) {
+    const record = await findTangledRepoRecord(pds, identity.did, repoName);
+    if (!record) {
       throw new Error(
-        `Could not resolve tangled repo "${path}" (HTTP ${response.status})`,
+        `Could not find a tangled repo record named "${repoName}" for "${ownerHandle}"`,
       );
     }
-    const record = await response.json();
-    const knot = record.value?.knot;
-    const repoDid = record.value?.repoDid;
+    const { knot, repoDid } = record;
     if (!knot || !repoDid) {
       throw new Error(
         `tangled repo record for "${path}" is missing knot/repoDid`,

--- a/src/js/plugins/sourceProvider.js
+++ b/src/js/plugins/sourceProvider.js
@@ -1,3 +1,5 @@
+import { resolveIdentity, getServiceEndpointFromDidDoc } from "/js/atproto.js";
+
 const REQUIRED_MANIFEST_FIELDS = ["id", "name", "version"];
 
 function isRelativePath(file) {
@@ -75,35 +77,6 @@ export function repoWebUrl(repo) {
   return `https://github.com/${path}`;
 }
 
-// GitHub's raw content host returns a clean 404 for a missing file.
-// tangled.sh's blob-fetch backend instead returns 500 with this exact JSON
-// error body for a missing blob — verified against a real repo, since it
-// has no dedicated "not found" status. Match on the body too (not just the
-// 500), so an actual tangled.sh outage still surfaces as a real error
-// instead of being silently swallowed as "file doesn't exist".
-function isTangledMissingBlobBody(body) {
-  if (typeof body !== "string") return false;
-  let parsed;
-  try {
-    parsed = JSON.parse(body);
-  } catch {
-    return false;
-  }
-  return (
-    parsed?.error === "InternalServerError" &&
-    parsed?.message === "failed to get blob"
-  );
-}
-
-function isMissingFileResponse(repo, status, body) {
-  if (status === 404) return true;
-  return (
-    parseRepoSpec(repo).host === "tangled" &&
-    status === 500 &&
-    isTangledMissingBlobBody(body)
-  );
-}
-
 function assertFontMagicBytes(file, bytes) {
   const view = new Uint8Array(bytes, 0, 4);
   const isWoff2 =
@@ -122,13 +95,85 @@ function assertFontMagicBytes(file, bytes) {
   }
 }
 
-function remoteAssetUrl({ repo, file, release = null }) {
+// tangled.org's own HTTP endpoints (the "/raw/<ref>/<path>" route and the
+// mirror.tangled.network XRPC service it redirects through) don't set
+// Access-Control-Allow-Origin, so browsers block fetching them cross-origin
+// entirely — this isn't fixable by changing the URL we hit on that host.
+//
+// Instead, resolve and fetch entirely through standard AT Protocol
+// infrastructure, which is CORS-enabled throughout (impro already depends
+// on plc.directory and the handle resolver for its own core function, so
+// this adds no new trust surface):
+//   1. resolveIdentity(ownerHandle) -> owner DID + DID doc (handle
+//      resolver + plc.directory)
+//   2. getServiceEndpointFromDidDoc -> owner's PDS
+//   3. com.atproto.repo.getRecord on the owner's PDS for the repo's own
+//      "sh.tangled.repo" record (rkey = repo name) -> {knot, repoDid}
+//   4. the individual knot server's own "sh.tangled.repo.blob" XRPC route
+//      (not the mirror), which does set Access-Control-Allow-Origin: *
+//
+// Cached per repo path since each resolution costs 3 network round-trips
+// and rarely changes.
+const tangledRepoInfoCache = new Map();
+
+async function resolveTangledRepoInfo(path) {
+  if (tangledRepoInfoCache.has(path)) {
+    return tangledRepoInfoCache.get(path);
+  }
+  const promise = (async () => {
+    const slashIndex = path.indexOf("/");
+    if (slashIndex === -1) {
+      throw new Error(`Invalid tangled repo path "${path}"`);
+    }
+    const ownerHandle = path.slice(0, slashIndex);
+    const repoName = path.slice(slashIndex + 1);
+
+    const identity = await resolveIdentity(ownerHandle);
+    if (!identity) {
+      throw new Error(`Could not resolve tangled repo owner "${ownerHandle}"`);
+    }
+    const pds = getServiceEndpointFromDidDoc(identity.didDoc);
+
+    const recordUrl =
+      `${pds}/xrpc/com.atproto.repo.getRecord?` +
+      new URLSearchParams({
+        repo: identity.did,
+        collection: "sh.tangled.repo",
+        rkey: repoName,
+      });
+    const response = await fetch(recordUrl);
+    if (!response.ok) {
+      throw new Error(
+        `Could not resolve tangled repo "${path}" (HTTP ${response.status})`,
+      );
+    }
+    const record = await response.json();
+    const knot = record.value?.knot;
+    const repoDid = record.value?.repoDid;
+    if (!knot || !repoDid) {
+      throw new Error(
+        `tangled repo record for "${path}" is missing knot/repoDid`,
+      );
+    }
+    return { knot, repoDid };
+  })();
+  // Don't cache a failed resolution — allow retrying on a later call.
+  promise.catch(() => tangledRepoInfoCache.delete(path));
+  tangledRepoInfoCache.set(path, promise);
+  return promise;
+}
+
+async function remoteAssetUrl({ repo, file, release = null }) {
   const { host, path } = parseRepoSpec(repo);
   if (host === "tangled") {
-    // tangled.sh serves raw blobs at /raw/<ref>/<path> for both branches
-    // and tags; there's no separate "refs/tags/..." form like GitHub's.
-    const ref = release ?? "main";
-    return `https://tangled.org/${path}/raw/${ref}/${file}`;
+    const { knot, repoDid } = await resolveTangledRepoInfo(path);
+    const params = new URLSearchParams({
+      repo: repoDid,
+      ref: release ?? "main",
+      path: file,
+      raw: "true",
+    });
+    return `https://${knot}/xrpc/sh.tangled.repo.blob?${params}`;
   }
   const ref = release ? `refs/tags/${release}` : "refs/heads/main";
   return `https://raw.githubusercontent.com/${path}/${ref}/${file}`;
@@ -150,7 +195,7 @@ export class SourceProvider {
     if (!version || !repo) {
       throw new Error("Version and repo are required");
     }
-    const url = remoteAssetUrl({
+    const url = await remoteAssetUrl({
       repo,
       file: "manifest.json",
       release: version,
@@ -167,7 +212,7 @@ export class SourceProvider {
       throw new Error("Repo is required");
     }
     // Fetch from main branch
-    const url = remoteAssetUrl({ repo, file: "manifest.json" });
+    const url = await remoteAssetUrl({ repo, file: "manifest.json" });
     const response = await fetch(url, { cache: "no-store" });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     return parsePluginManifest(pluginId, await response.json());
@@ -177,7 +222,7 @@ export class SourceProvider {
     if (!repo) {
       throw new Error("Repo is required");
     }
-    const url = remoteAssetUrl({ repo, file: "manifest.json" });
+    const url = await remoteAssetUrl({ repo, file: "manifest.json" });
     const response = await fetch(url, { cache: "no-store" });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     const manifest = await response.json();
@@ -193,7 +238,11 @@ export class SourceProvider {
     if (!version || !repo) {
       throw new Error("Version and repo are required");
     }
-    const url = remoteAssetUrl({ repo, file: "main.js", release: version });
+    const url = await remoteAssetUrl({
+      repo,
+      file: "main.js",
+      release: version,
+    });
     const response = await this.pluginCache.fetch(url);
     return await response.text();
   }
@@ -209,15 +258,18 @@ export class SourceProvider {
     if (!version || !repo) {
       throw new Error("Version and repo are required");
     }
-    const url = remoteAssetUrl({ repo, file: "styles.css", release: version });
+    const url = await remoteAssetUrl({
+      repo,
+      file: "styles.css",
+      release: version,
+    });
     try {
       const response = await this.pluginCache.fetch(url, {
         doCacheNotFound: true,
-        isNotFound: (status, body) => isMissingFileResponse(repo, status, body),
       });
       return await response.text();
     } catch (error) {
-      if (isMissingFileResponse(repo, error?.status, error?.body)) return null;
+      if (error?.status === 404) return null;
       throw error;
     }
   }
@@ -232,7 +284,7 @@ export class SourceProvider {
       if (!version || !repo) {
         throw new Error("Version and repo are required");
       }
-      const url = remoteAssetUrl({ repo, file, release: version });
+      const url = await remoteAssetUrl({ repo, file, release: version });
       const response = await this.pluginCache.fetch(url);
       bytes = await response.arrayBuffer();
     }
@@ -252,14 +304,11 @@ export class SourceProvider {
       throw new Error("Repo is required");
     }
     // Fetch from main branch so we show the latest README
-    const url = remoteAssetUrl({ repo, file: "README.md" });
+    const url = await remoteAssetUrl({ repo, file: "README.md" });
     const response = await fetch(url, { cache: "no-store" });
-    const body = await response.text();
-    if (!response.ok) {
-      if (isMissingFileResponse(repo, response.status, body)) return null;
-      throw new Error(`HTTP ${response.status}`);
-    }
-    return body;
+    if (response.status === 404) return null;
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return await response.text();
   }
 
   // URLs that should be retained in the cache
@@ -269,14 +318,16 @@ export class SourceProvider {
       return [];
     }
     const urls = [
-      remoteAssetUrl({ repo, file: "manifest.json", release: version }),
-      remoteAssetUrl({ repo, file: "main.js", release: version }),
-      remoteAssetUrl({ repo, file: "styles.css", release: version }),
+      await remoteAssetUrl({ repo, file: "manifest.json", release: version }),
+      await remoteAssetUrl({ repo, file: "main.js", release: version }),
+      await remoteAssetUrl({ repo, file: "styles.css", release: version }),
     ];
     try {
       const manifest = await this.getManifest(pluginId, version, repo);
       for (const font of manifest.fonts ?? []) {
-        urls.push(remoteAssetUrl({ repo, file: font.file, release: version }));
+        urls.push(
+          await remoteAssetUrl({ repo, file: font.file, release: version }),
+        );
       }
     } catch {
       // If the manifest can't be read the base URLs are still returned so

--- a/src/js/plugins/sourceProvider.js
+++ b/src/js/plugins/sourceProvider.js
@@ -163,7 +163,12 @@ async function resolveTangledRepoInfo(path) {
   return promise;
 }
 
-async function remoteAssetUrl({ repo, file, release = null }) {
+// The knot's raw=true mode only serves image/video/text mime types (fonts
+// come back 403 "only image, video, and text files can be accessed
+// directly"). Passing raw=false instead gets the JSON-wrapped response
+// (content + encoding, "base64" for binary files) that every file type
+// supports — needed for fonts, usable for any file type.
+async function remoteAssetUrl({ repo, file, release = null, raw = true }) {
   const { host, path } = parseRepoSpec(repo);
   if (host === "tangled") {
     const { knot, repoDid } = await resolveTangledRepoInfo(path);
@@ -171,12 +176,29 @@ async function remoteAssetUrl({ repo, file, release = null }) {
       repo: repoDid,
       ref: release ?? "main",
       path: file,
-      raw: "true",
     });
+    if (raw) params.set("raw", "true");
     return `https://${knot}/xrpc/sh.tangled.repo.blob?${params}`;
   }
   const ref = release ? `refs/tags/${release}` : "refs/heads/main";
   return `https://raw.githubusercontent.com/${path}/${ref}/${file}`;
+}
+
+// Decodes a tangled knot's JSON-wrapped blob response (from a non-raw
+// sh.tangled.repo.blob fetch) into an ArrayBuffer.
+function decodeTangledBlobContent(data, file) {
+  if (typeof data.content !== "string") {
+    throw new Error(`tangled blob response for "${file}" has no content`);
+  }
+  if (data.encoding === "base64") {
+    const binary = atob(data.content);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes.buffer;
+  }
+  return new TextEncoder().encode(data.content).buffer;
 }
 
 export class SourceProvider {
@@ -284,9 +306,21 @@ export class SourceProvider {
       if (!version || !repo) {
         throw new Error("Version and repo are required");
       }
-      const url = await remoteAssetUrl({ repo, file, release: version });
-      const response = await this.pluginCache.fetch(url);
-      bytes = await response.arrayBuffer();
+      const { host } = parseRepoSpec(repo);
+      if (host === "tangled") {
+        const url = await remoteAssetUrl({
+          repo,
+          file,
+          release: version,
+          raw: false,
+        });
+        const response = await this.pluginCache.fetch(url);
+        bytes = decodeTangledBlobContent(await response.json(), file);
+      } else {
+        const url = await remoteAssetUrl({ repo, file, release: version });
+        const response = await this.pluginCache.fetch(url);
+        bytes = await response.arrayBuffer();
+      }
     }
     assertFontMagicBytes(file, bytes);
     const mime = /\.woff2$/i.test(file) ? "font/woff2" : "font/woff";

--- a/tests/unit/specs/sourceProvider.test.js
+++ b/tests/unit/specs/sourceProvider.test.js
@@ -239,10 +239,7 @@ describe("SourceProvider with remote plugins", () => {
       pluginCache.calls[0].url,
       "https://raw.githubusercontent.com/ow/alpha/refs/tags/1.0.0/styles.css",
     );
-    const { doCacheNotFound, isNotFound } = pluginCache.calls[0].options;
-    assert.deepEqual(doCacheNotFound, true);
-    assert.deepEqual(isNotFound(404, null), true);
-    assert.deepEqual(isNotFound(500, "boom"), false);
+    assert.deepEqual(pluginCache.calls[0].options, { doCacheNotFound: true });
     assert.deepEqual(styles, "body{color:blue}");
   });
 
@@ -522,25 +519,115 @@ describe("SourceProvider.getCacheUrls with fonts", () => {
   });
 });
 
+// tangled.org's own HTTP endpoints don't set CORS headers, so
+// SourceProvider resolves tangled: repos entirely through standard AT
+// Protocol infrastructure instead: resolveHandle -> plc.directory ->
+// the owner's PDS (for the repo's own "sh.tangled.repo" record, which
+// carries {knot, repoDid}) -> the knot's own CORS-enabled blob endpoint.
+// This stubs global fetch to answer those three resolution requests by URL
+// pattern; the actual file-content request is left to the caller (via
+// fakePluginCache, or a 4th branch here for plain-fetch methods).
+function stubTangledResolution({
+  ownerHandle,
+  ownerDid,
+  pds,
+  knot,
+  repoDid,
+  content = null,
+}) {
+  const calls = [];
+  const fetchImpl = async (url, options) => {
+    calls.push({ url: String(url), options });
+    const urlStr = String(url);
+    if (urlStr.includes("com.atproto.identity.resolveHandle")) {
+      return jsonResponse({ did: ownerDid });
+    }
+    if (urlStr.startsWith("https://plc.directory/")) {
+      return jsonResponse({
+        id: ownerDid,
+        alsoKnownAs: [`at://${ownerHandle}`],
+        service: [
+          {
+            id: "#atproto_pds",
+            type: "AtprotoPersonalDataServer",
+            serviceEndpoint: pds,
+          },
+        ],
+      });
+    }
+    if (
+      urlStr.startsWith(pds) &&
+      urlStr.includes("com.atproto.repo.getRecord")
+    ) {
+      return jsonResponse({ value: { knot, repoDid } });
+    }
+    if (content && urlStr.startsWith(`https://${knot}/`)) {
+      return content;
+    }
+    throw new Error(`Unexpected fetch in stubTangledResolution: ${urlStr}`);
+  };
+  const originalGlobal = globalThis.fetch;
+  const originalWindow = globalThis.window.fetch;
+  globalThis.fetch = fetchImpl;
+  globalThis.window.fetch = fetchImpl;
+  return {
+    calls,
+    restore() {
+      globalThis.fetch = originalGlobal;
+      globalThis.window.fetch = originalWindow;
+    },
+  };
+}
+
+function knotBlobUrl({ knot, repoDid, ref, path }) {
+  const params = new URLSearchParams({ repo: repoDid, ref, path, raw: "true" });
+  return `https://${knot}/xrpc/sh.tangled.repo.blob?${params}`;
+}
+
+// resolveTangledRepoInfo caches per repo path at module scope, so each test
+// below uses its own unique owner handle to avoid one test's cached
+// resolution masking another test's stub (and hiding real bugs).
+let identityCounter = 0;
+function makeIdentity() {
+  const n = ++identityCounter;
+  return {
+    ownerHandle: `owner${n}.example`,
+    ownerDid: `did:plc:owner${n}`,
+    pds: `https://pds${n}.example`,
+    knot: `knot${n}.example`,
+    repoDid: `did:plc:repo${n}`,
+  };
+}
+
 describe("SourceProvider with tangled.sh-hosted plugins", () => {
-  it("fetches a versioned manifest from tangled.org via plugin cache", async () => {
+  it("resolves via atproto and fetches a versioned manifest from the knot", async () => {
+    const identity = makeIdentity();
+    const stub = stubTangledResolution(identity);
     const pluginCache = fakePluginCache(async () =>
       jsonResponse({ id: "alpha", name: "A", version: "1.0.0" }),
     );
-    const provider = new SourceProvider(pluginCache);
-    const manifest = await provider.getManifest(
-      "alpha",
-      "1.0.0",
-      "tangled:ow/alpha",
-    );
-    assert.deepEqual(
-      pluginCache.calls[0].url,
-      "https://tangled.org/ow/alpha/raw/1.0.0/manifest.json",
-    );
-    assert.deepEqual(manifest.id, "alpha");
+    try {
+      const provider = new SourceProvider(pluginCache);
+      const manifest = await provider.getManifest(
+        "alpha",
+        "1.0.0",
+        `tangled:${identity.ownerHandle}/alpha`,
+      );
+      assert.deepEqual(
+        pluginCache.calls[0].url,
+        knotBlobUrl({ ...identity, ref: "1.0.0", path: "manifest.json" }),
+      );
+      assert.deepEqual(manifest.id, "alpha");
+      // resolveHandle, plc.directory, getRecord
+      assert.deepEqual(stub.calls.length, 3);
+    } finally {
+      stub.restore();
+    }
   });
 
   it("fetches source from the version that was passed in", async () => {
+    const identity = makeIdentity();
+    const stub = stubTangledResolution(identity);
     const pluginCache = fakePluginCache(async () => ({
       ok: true,
       status: 200,
@@ -548,51 +635,84 @@ describe("SourceProvider with tangled.sh-hosted plugins", () => {
         return "alert(1)";
       },
     }));
-    const provider = new SourceProvider(pluginCache);
-    const source = await provider.getSource(
-      "alpha",
-      "2.5.0",
-      "tangled:ow/alpha",
-    );
-    assert.deepEqual(
-      pluginCache.calls[0].url,
-      "https://tangled.org/ow/alpha/raw/2.5.0/main.js",
-    );
-    assert.deepEqual(source, "alert(1)");
-  });
-
-  it("getLiveManifest fetches from the main branch", async () => {
-    const stub = stubFetch(async () =>
-      jsonResponse({ id: "alpha", name: "A", version: "9.9.9" }),
-    );
     try {
-      const provider = new SourceProvider(null);
-      const manifest = await provider.getLiveManifest(
+      const provider = new SourceProvider(pluginCache);
+      const source = await provider.getSource(
         "alpha",
-        "tangled:ow/alpha",
+        "2.5.0",
+        `tangled:${identity.ownerHandle}/alpha`,
       );
       assert.deepEqual(
-        stub.calls[0].url,
-        "https://tangled.org/ow/alpha/raw/main/manifest.json",
+        pluginCache.calls[0].url,
+        knotBlobUrl({ ...identity, ref: "2.5.0", path: "main.js" }),
       );
-      assert.deepEqual(manifest.version, "9.9.9");
+      assert.deepEqual(source, "alert(1)");
     } finally {
       stub.restore();
     }
   });
 
-  it("getCacheUrls includes manifest, main.js, and styles.css URLs", async () => {
-    const provider = new SourceProvider(null);
-    const urls = await provider.getCacheUrls(
-      "alpha",
-      "1.2.3",
-      "tangled:ow/alpha",
+  it("getLiveManifest resolves via atproto and fetches from the knot's main ref", async () => {
+    const identity = makeIdentity();
+    const stub = stubTangledResolution({
+      ...identity,
+      content: jsonResponse({ id: "alpha", name: "A", version: "9.9.9" }),
+    });
+    try {
+      const provider = new SourceProvider(null);
+      const manifest = await provider.getLiveManifest(
+        "alpha",
+        `tangled:${identity.ownerHandle}/alpha`,
+      );
+      assert.deepEqual(manifest.version, "9.9.9");
+      const finalCall = stub.calls.at(-1);
+      assert.deepEqual(
+        finalCall.url,
+        knotBlobUrl({ ...identity, ref: "main", path: "manifest.json" }),
+      );
+    } finally {
+      stub.restore();
+    }
+  });
+
+  it("caches the resolved knot/repoDid so a second fetch doesn't re-resolve", async () => {
+    const identity = makeIdentity();
+    const stub = stubTangledResolution(identity);
+    const pluginCache = fakePluginCache(async () =>
+      jsonResponse({ id: "alpha", name: "A", version: "1.0.0" }),
     );
-    assert.deepEqual(urls, [
-      "https://tangled.org/ow/alpha/raw/1.2.3/manifest.json",
-      "https://tangled.org/ow/alpha/raw/1.2.3/main.js",
-      "https://tangled.org/ow/alpha/raw/1.2.3/styles.css",
-    ]);
+    try {
+      const provider = new SourceProvider(pluginCache);
+      const repo = `tangled:${identity.ownerHandle}/alpha`;
+      await provider.getManifest("alpha", "1.0.0", repo);
+      await provider.getSource("alpha", "1.0.0", repo);
+      // Still just the 3 resolution calls, not 6 — the second fetch reused
+      // the cached {knot, repoDid}.
+      assert.deepEqual(stub.calls.length, 3);
+      assert.deepEqual(pluginCache.calls.length, 2);
+    } finally {
+      stub.restore();
+    }
+  });
+
+  it("getCacheUrls resolves once and includes manifest, main.js, and styles.css URLs", async () => {
+    const identity = makeIdentity();
+    const stub = stubTangledResolution(identity);
+    try {
+      const provider = new SourceProvider(null);
+      const urls = await provider.getCacheUrls(
+        "alpha",
+        "1.2.3",
+        `tangled:${identity.ownerHandle}/alpha`,
+      );
+      assert.deepEqual(urls, [
+        knotBlobUrl({ ...identity, ref: "1.2.3", path: "manifest.json" }),
+        knotBlobUrl({ ...identity, ref: "1.2.3", path: "main.js" }),
+        knotBlobUrl({ ...identity, ref: "1.2.3", path: "styles.css" }),
+      ]);
+    } finally {
+      stub.restore();
+    }
   });
 
   it("throws for an unrecognized repo host prefix", async () => {
@@ -606,110 +726,60 @@ describe("SourceProvider with tangled.sh-hosted plugins", () => {
     assert(caught?.message.includes('Unsupported plugin repo host "gitlab"'));
   });
 
-  // tangled.sh's blob backend returns 500 (not 404) for a missing file, so
-  // "optional file absent" detection has to special-case it per host.
-  const TANGLED_MISSING_BLOB_BODY = JSON.stringify({
-    error: "InternalServerError",
-    message: "failed to get blob",
-  });
-
-  it("getStyles treats tangled's missing-blob 500 as a missing styles.css, not an error", async () => {
-    const pluginCache = fakePluginCache(async () => {
-      const error = new Error("HTTP 500");
-      error.status = 500;
-      error.body = TANGLED_MISSING_BLOB_BODY;
-      throw error;
-    });
-    const provider = new SourceProvider(pluginCache);
-    const styles = await provider.getStyles(
-      "alpha",
-      "1.0.0",
-      "tangled:ow/alpha",
-    );
-    assert.deepEqual(styles, null);
-    const { isNotFound } = pluginCache.calls[0].options;
-    assert.deepEqual(isNotFound(500, TANGLED_MISSING_BLOB_BODY), true);
-    assert.deepEqual(isNotFound(500, "boom"), false);
-    assert.deepEqual(isNotFound(404, null), true);
-  });
-
-  it("getStyles still throws a tangled 500 with an unrelated body", async () => {
-    const pluginCache = fakePluginCache(async () => {
-      const error = new Error("HTTP 500");
-      error.status = 500;
-      error.body = JSON.stringify({ error: "InternalServerError" });
-      throw error;
-    });
-    const provider = new SourceProvider(pluginCache);
-    let caught = null;
+  it("throws a clear error when the owner handle can't be resolved", async () => {
+    const stub = stubFetch(async () => jsonResponse({ did: null }));
     try {
-      await provider.getStyles("alpha", "1.0.0", "tangled:ow/alpha");
-    } catch (error) {
-      caught = error;
-    }
-    assert.deepEqual(caught?.status, 500);
-  });
-
-  it("getStyles still throws a tangled 500 with a non-JSON body", async () => {
-    const pluginCache = fakePluginCache(async () => {
-      const error = new Error("HTTP 500");
-      error.status = 500;
-      error.body = "<html>gateway error</html>";
-      throw error;
-    });
-    const provider = new SourceProvider(pluginCache);
-    let caught = null;
-    try {
-      await provider.getStyles("alpha", "1.0.0", "tangled:ow/alpha");
-    } catch (error) {
-      caught = error;
-    }
-    assert.deepEqual(caught?.status, 500);
-  });
-
-  it("getStyles still throws a matching-body 500 for non-tangled repos", async () => {
-    const pluginCache = fakePluginCache(async () => {
-      const error = new Error("HTTP 500");
-      error.status = 500;
-      error.body = TANGLED_MISSING_BLOB_BODY;
-      throw error;
-    });
-    const provider = new SourceProvider(pluginCache);
-    let caught = null;
-    try {
-      await provider.getStyles("alpha", "1.0.0", "ow/alpha");
-    } catch (error) {
-      caught = error;
-    }
-    assert.deepEqual(caught?.status, 500);
-  });
-
-  it("getReadme treats tangled's missing-blob 500 as a missing README, not an error", async () => {
-    const stub = stubFetch(async () =>
-      jsonResponse(TANGLED_MISSING_BLOB_BODY, { ok: false, status: 500 }),
-    );
-    try {
-      const provider = new SourceProvider(null);
-      const readme = await provider.getReadme("alpha", "tangled:ow/alpha");
-      assert.deepEqual(readme, null);
+      const provider = new SourceProvider(fakePluginCache(async () => null));
+      let caught = null;
+      try {
+        await provider.getManifest(
+          "alpha",
+          "1.0.0",
+          "tangled:unknown.example/alpha",
+        );
+      } catch (error) {
+        caught = error;
+      }
+      assert(caught?.message.includes("Could not resolve tangled repo owner"));
     } finally {
       stub.restore();
     }
   });
 
-  it("getReadme still throws a tangled 500 with an unrelated body", async () => {
-    const stub = stubFetch(async () =>
-      jsonResponse("server exploded", { ok: false, status: 500 }),
-    );
+  it("getStyles returns null when the knot 404s (no styles.css)", async () => {
+    const identity = makeIdentity();
+    const stub = stubTangledResolution(identity);
+    const pluginCache = fakePluginCache(async () => {
+      const error = new Error("HTTP 404");
+      error.status = 404;
+      throw error;
+    });
+    try {
+      const provider = new SourceProvider(pluginCache);
+      const styles = await provider.getStyles(
+        "alpha",
+        "1.0.0",
+        `tangled:${identity.ownerHandle}/alpha`,
+      );
+      assert.deepEqual(styles, null);
+    } finally {
+      stub.restore();
+    }
+  });
+
+  it("getReadme returns null when the knot 404s (no README.md)", async () => {
+    const identity = makeIdentity();
+    const stub = stubTangledResolution({
+      ...identity,
+      content: { ok: false, status: 404 },
+    });
     try {
       const provider = new SourceProvider(null);
-      let caught = null;
-      try {
-        await provider.getReadme("alpha", "tangled:ow/alpha");
-      } catch (error) {
-        caught = error;
-      }
-      assert(caught?.message.includes("500"));
+      const readme = await provider.getReadme(
+        "alpha",
+        `tangled:${identity.ownerHandle}/alpha`,
+      );
+      assert.deepEqual(readme, null);
     } finally {
       stub.restore();
     }

--- a/tests/unit/specs/sourceProvider.test.js
+++ b/tests/unit/specs/sourceProvider.test.js
@@ -527,13 +527,20 @@ describe("SourceProvider.getCacheUrls with fonts", () => {
 // This stubs global fetch to answer those three resolution requests by URL
 // pattern; the actual file-content request is left to the caller (via
 // fakePluginCache, or a 4th branch here for plain-fetch methods).
+// legacyRecordKey simulates repos created before the "rkey = repo name"
+// scheme existed: the direct getRecord lookup 404s (well, 400s — standard
+// atproto RecordNotFound), and the record only turns up via listRecords,
+// keyed by an opaque TID with an explicit "name" field. Confirmed for real
+// against tangled.org's own account (its "infra" repo still uses this).
 function stubTangledResolution({
   ownerHandle,
   ownerDid,
   pds,
   knot,
   repoDid,
+  repoName = "alpha",
   content = null,
+  legacyRecordKey = false,
 }) {
   const calls = [];
   const fetchImpl = async (url, options) => {
@@ -559,7 +566,31 @@ function stubTangledResolution({
       urlStr.startsWith(pds) &&
       urlStr.includes("com.atproto.repo.getRecord")
     ) {
+      if (legacyRecordKey) {
+        return jsonResponse(
+          { error: "RecordNotFound", message: "not found" },
+          { ok: false, status: 400 },
+        );
+      }
       return jsonResponse({ value: { knot, repoDid } });
+    }
+    if (
+      urlStr.startsWith(pds) &&
+      urlStr.includes("com.atproto.repo.listRecords")
+    ) {
+      if (!legacyRecordKey) {
+        throw new Error(
+          "listRecords should only be hit as a fallback (legacyRecordKey: true)",
+        );
+      }
+      return jsonResponse({
+        records: [
+          {
+            uri: `at://${ownerDid}/sh.tangled.repo/3lxfwy4ifg622`,
+            value: { knot, repoDid, name: repoName },
+          },
+        ],
+      });
     }
     if (content && urlStr.startsWith(`https://${knot}/`)) {
       return content;
@@ -741,6 +772,64 @@ describe("SourceProvider with tangled.sh-hosted plugins", () => {
         caught = error;
       }
       assert(caught?.message.includes("Could not resolve tangled repo owner"));
+    } finally {
+      stub.restore();
+    }
+  });
+
+  it("falls back to listRecords for repos using the older TID record key", async () => {
+    const identity = makeIdentity();
+    const stub = stubTangledResolution({
+      ...identity,
+      repoName: "alpha",
+      legacyRecordKey: true,
+    });
+    const pluginCache = fakePluginCache(async () =>
+      jsonResponse({ id: "alpha", name: "A", version: "1.0.0" }),
+    );
+    try {
+      const provider = new SourceProvider(pluginCache);
+      const manifest = await provider.getManifest(
+        "alpha",
+        "1.0.0",
+        `tangled:${identity.ownerHandle}/alpha`,
+      );
+      assert.deepEqual(manifest.id, "alpha");
+      assert.deepEqual(
+        pluginCache.calls[0].url,
+        knotBlobUrl({ ...identity, ref: "1.0.0", path: "manifest.json" }),
+      );
+      // resolveHandle, plc.directory, getRecord (404), listRecords
+      assert.deepEqual(stub.calls.length, 4);
+    } finally {
+      stub.restore();
+    }
+  });
+
+  it("throws a clear error when no record matches by rkey or name", async () => {
+    const identity = makeIdentity();
+    const stub = stubTangledResolution({
+      ...identity,
+      repoName: "some-other-repo",
+      legacyRecordKey: true,
+    });
+    try {
+      const provider = new SourceProvider(fakePluginCache(async () => null));
+      let caught = null;
+      try {
+        await provider.getManifest(
+          "alpha",
+          "1.0.0",
+          `tangled:${identity.ownerHandle}/alpha`,
+        );
+      } catch (error) {
+        caught = error;
+      }
+      assert(
+        caught?.message.includes(
+          'Could not find a tangled repo record named "alpha"',
+        ),
+      );
     } finally {
       stub.restore();
     }

--- a/tests/unit/specs/sourceProvider.test.js
+++ b/tests/unit/specs/sourceProvider.test.js
@@ -785,3 +785,75 @@ describe("SourceProvider with tangled.sh-hosted plugins", () => {
     }
   });
 });
+
+// The knot's raw=true mode 403s for font mime types, so getFont fetches the
+// JSON-wrapped (base64) response for tangled repos instead and decodes it
+// client-side. Verified against a real binary file on the live server
+// (byte-for-byte identical to a raw=true fetch of the same file) separately
+// from this suite; these tests cover the decode logic in isolation.
+function wrappedFontResponse(bytes) {
+  return jsonResponse({
+    content: Buffer.from(bytes).toString("base64"),
+    encoding: "base64",
+    isBinary: true,
+  });
+}
+
+describe("SourceProvider.getFont with tangled.sh-hosted plugins", () => {
+  it("fetches the non-raw wrapped response and decodes it into a Blob", async () => {
+    const identity = makeIdentity();
+    const stub = stubTangledResolution(identity);
+    const bytes = woff2Bytes();
+    const pluginCache = fakePluginCache(async () => wrappedFontResponse(bytes));
+    try {
+      const provider = new SourceProvider(pluginCache);
+      const blob = await provider.getFont(
+        "alpha",
+        "1.0.0",
+        `tangled:${identity.ownerHandle}/alpha`,
+        "fonts/f.woff2",
+      );
+      const params = new URLSearchParams({
+        repo: identity.repoDid,
+        ref: "1.0.0",
+        path: "fonts/f.woff2",
+      });
+      assert.deepEqual(
+        pluginCache.calls[0].url,
+        `https://${identity.knot}/xrpc/sh.tangled.repo.blob?${params}`,
+      );
+      assert(!pluginCache.calls[0].url.includes("raw="));
+      assert(blob instanceof Blob);
+      assert.deepEqual(blob.type, "font/woff2");
+      assert.deepEqual(blob.size, bytes.byteLength);
+    } finally {
+      stub.restore();
+    }
+  });
+
+  it("rejects invalid magic bytes the same way as GitHub/local fonts", async () => {
+    const identity = makeIdentity();
+    const stub = stubTangledResolution(identity);
+    const notFont = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0]);
+    const pluginCache = fakePluginCache(async () =>
+      wrappedFontResponse(notFont),
+    );
+    try {
+      const provider = new SourceProvider(pluginCache);
+      let caught = null;
+      try {
+        await provider.getFont(
+          "alpha",
+          "1.0.0",
+          `tangled:${identity.ownerHandle}/alpha`,
+          "fonts/f.woff2",
+        );
+      } catch (error) {
+        caught = error;
+      }
+      assert(caught?.message.includes("invalid magic bytes"));
+    } finally {
+      stub.restore();
+    }
+  });
+});


### PR DESCRIPTION
So sorry about earlier! Should have done it through atproto instead of relying on the tangled website in the first place.
This time tested the full install path through Advanced->Install from URL
This has the fortunate side-effect of removing the custom 500->404 error path, since that's something only the website does.

Robot says:
tangled.org's own HTTP endpoints (the "/raw/<ref>/<path>" route and the
mirror.tangled.network XRPC service it redirects through) don't set
Access-Control-Allow-Origin, so a browser fetch to them is blocked by
CORS entirely — confirmed with a real deployment (Profile & Moderation
Tools failed to load with a CORS error, status 302). This isn't fixable
by changing the URL on that host; the server has to opt in, and it
currently doesn't.

Instead, this resolves and fetches tangled: repos entirely through
standard AT Protocol infrastructure, which is CORS-enabled throughout
and already core to how Impro works (it already depends on
plc.directory and the handle resolver for its own identity resolution,
so this adds no new trust surface):

  1. resolveHandle(ownerHandle) -> owner DID (handle resolver)
  2. plc.directory -> owner's PDS
  3. com.atproto.repo.getRecord on the owner's PDS for the repo's own
     "sh.tangled.repo" record (rkey = repo name) -> {knot, repoDid}
  4. the individual knot server's own "sh.tangled.repo.blob" XRPC route
     (not the mirror tangled.org's /raw/ redirects through) -> file
     content, with proper CORS headers

Resolution is cached per repo path since it costs 3 round-trips and
rarely changes.

Also fixes font loading over tangled hosting: the knot's raw=true mode
403s for font mime types (only image/video/text are allowed in raw
mode), so getFont now uses the endpoint's non-raw JSON+base64 mode
instead and decodes client-side — same mechanism, no restriction.

Verified against the real profile-moderation-tools repo: manifest,
versioned tag fetch, source, missing-file handling (styles.css/README),
and a byte-for-byte comparison of a real binary file fetched via
raw=true vs the decoded wrapped response. Also confirmed no regression
for GitHub-hosted plugins.