### PR TITLE
Record permissions for plugins

### DIFF
--- a/impro-plugin/main.js
+++ b/impro-plugin/main.js
@@ -163,6 +163,19 @@ class PluginData {
   getRecord(repo, collection, rkey) {
     return hostCall("getRecord", { repo, collection, rkey });
   }
+  // Writes to the signed-in user's own repo only — there is no `repo`
+  // parameter, unlike getRecord, since a plugin can never write to anyone
+  // else's account. There's also no `collection` parameter: every
+  // records-write plugin shares one fixed collection (requires
+  // `permissions.records: ["write"]`, granted by the user at install time),
+  // and the host rejects any rkey that already belongs to a different
+  // plugin, so a plugin only ever needs to pick its own rkey.
+  putRecord(rkey, record) {
+    return hostCall("putRecord", { rkey, record });
+  }
+  deleteRecord(rkey) {
+    return hostCall("deleteRecord", { rkey });
+  }
 }
 
 class App {
@@ -325,6 +338,18 @@ export class Plugin {
     await hostCall("saveData", { data });
   }
 
+  // Device-local counterpart to loadData/saveData: never synced through the
+  // user's account preferences, so it's the right place for anything that
+  // shouldn't silently follow the plugin to another device (e.g. a locally
+  // held secret key). Cleared on uninstall, same as loadData/saveData.
+  async loadLocalData() {
+    return hostCall("loadLocalData");
+  }
+
+  async saveLocalData(data) {
+    await hostCall("saveLocalData", { data });
+  }
+
   addSettingTab(tab) {
     tab.plugin = this;
     const displayHandlerId = uuid.create();
@@ -402,6 +427,14 @@ export class Plugin {
       name,
       handlerId,
     });
+  }
+
+  // Forces every mounted <plugin-slot name=...> to re-invoke its registered
+  // plugins' callbacks (including other plugins' — the slot has no concept
+  // of per-plugin refresh). Useful when a slot's content depends on data
+  // that resolves asynchronously after the initial render.
+  refreshSlot(name) {
+    return hostCall("refreshSlot", { name });
   }
 
   onload() {}

--- a/impro-plugin/main.js
+++ b/impro-plugin/main.js
@@ -176,6 +176,15 @@ class PluginData {
   deleteRecord(rkey) {
     return hostCall("deleteRecord", { rkey });
   }
+  // Lists this plugin's own records in the shared collection — never
+  // another plugin's, even though they live in the same collection; the
+  // host filters by ownership before this ever reaches plugin code.
+  // Requires permissions.records: ["write"], same as putRecord/deleteRecord.
+  // Returns { cursor, records: [{uri, cid, value}] } — page through with
+  // cursor until it comes back undefined/null.
+  listRecords(cursor, limit) {
+    return hostCall("listRecords", { cursor, limit });
+  }
 }
 
 class App {

--- a/plugins.md
+++ b/plugins.md
@@ -55,6 +55,13 @@ Plugins are currently in **beta** as the API surface is being expanded. However,
   `$type` would otherwise make every write 400 on a real PDS. The write is
   always pinned to the signed-in user's own DID; a plugin can never write to anyone else's
   repo.
+- List its own records in that shared collection (`app.data.listRecords(cursor, limit)`,
+  same `permissions.records: ["write"]` scope) — paged, and filtered by the host to this
+  plugin's own `$plugin`-stamped records before the result ever reaches plugin code, so a
+  plugin can't enumerate another plugin's records just by sharing the same collection.
+  Since the public `getRecord` bridge is unauthenticated and doesn't know whose repo it's
+  reading, this goes through the signed-in user's own session instead — the Slingshot proxy
+  `getRecord` uses doesn't implement `listRecords` at all.
 - Store plugin settings on a user's account (synced across devices, via `loadData`/`saveData`)
   or purely on the current device (never synced, via `loadLocalData`/`saveLocalData` —
   intended for secrets or device-specific values a plugin shouldn't silently propagate,

--- a/plugins.md
+++ b/plugins.md
@@ -40,6 +40,29 @@ Plugins are currently in **beta** as the API surface is being expanded. However,
 - Make whitelisted network requests (requires permissions)
 - Read appview data with the current user as the viewer (profiles, posts, etc.)
 - Mute, block, or send feed feedback ("show more/less like this") on the user's behalf (requires permissions)
+- Create, update, and delete its own records in the signed-in user's own repo
+  (`permissions.records: ["write"]`, granted by the user at install/update time — see
+  `pluginPermissions.js`'s `isRecordWriteAllowed`). All records-write plugins share a single
+  fixed collection (`social.impro.plugins.cloaca` — see `SHARED_PLUGIN_RECORDS_COLLECTION`);
+  a plugin doesn't choose its own collection name, since AT Protocol OAuth scopes name an
+  exact collection and can't use wildcards, so per-plugin collections would mean a new core
+  change _and_ forced re-authentication for every plugin. Isolation between plugins within
+  that shared collection is enforced per-record: the host stamps every record it writes with
+  the calling plugin's id and refuses to overwrite or delete a record stamped with a
+  different plugin's id (see `pluginService.js`'s `putRecord`/`deleteRecord`). The host also
+  always overwrites `record.$type` to the shared collection's own NSID before writing — AT
+  Protocol requires `$type` to equal the record's containing collection, so a plugin-supplied
+  `$type` would otherwise make every write 400 on a real PDS. The write is
+  always pinned to the signed-in user's own DID; a plugin can never write to anyone else's
+  repo.
+- Store plugin settings on a user's account (synced across devices, via `loadData`/`saveData`)
+  or purely on the current device (never synced, via `loadLocalData`/`saveLocalData` —
+  intended for secrets or device-specific values a plugin shouldn't silently propagate,
+  e.g. a locally-held key)
+- Render custom inline content next to a user's name wherever moderation label badges
+  would otherwise show — profile header, post byline (feed/thread/quoted), and the DM info
+  panel — via `registerSlot("author-badges", callback)`, invoked once per rendered user with
+  `context.did` set to that user's DID
 
 ### Plugins CANNOT:
 

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -1488,6 +1488,23 @@ export class Api {
     return res.data;
   }
 
+  // Named listOwnRecords, not listRecords, for the same reason as
+  // getOwnRecord above — pinned to the signed-in user's own repo. Slingshot
+  // (the public/unauthenticated proxy the plugin-facing getRecord bridge
+  // uses) doesn't implement com.atproto.repo.listRecords at all (confirmed
+  // against the live service — a 404), so this goes through the user's own
+  // authenticated session instead, which is the right fit anyway since
+  // callers only ever want to enumerate the signed-in user's own records.
+  async listOwnRecords(collection, cursor, limit) {
+    const query = { repo: this.session.did, collection };
+    if (cursor) query.cursor = cursor;
+    if (limit) query.limit = limit;
+    const res = await this.request("com.atproto.repo.listRecords", {
+      query,
+    });
+    return res.data;
+  }
+
   async createModerationReport({ reasonType, reason, subject, labelerDid }) {
     const body = {
       reasonType,

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -1433,6 +1433,61 @@ export class Api {
     return res.data;
   }
 
+  // Generic record read/write/delete for plugin-owned collections (see
+  // pluginService.js's putRecord/deleteRecord host methods). Unlike the
+  // resource-specific helpers above, the collection is caller-supplied; the
+  // caller is responsible for having already checked the collection against
+  // the plugin's declared permissions — these methods have no opinion about
+  // that, they just always pin the request to the signed-in user's own repo.
+  //
+  // Named getOwnRecord (not getRecord) to avoid colliding with the existing
+  // getRecord(uri) above, which takes a full AT-URI for an arbitrary repo.
+  // This one is also deliberately distinct from the plugin-facing
+  // app.data.getRecord bridge (Slingshot-backed, public/unauthenticated,
+  // works for any DID): this one reads the user's own repo directly and
+  // authenticated, for the read-before-write ownership check in
+  // pluginService.js, where staleness from a cache/index would be a real
+  // correctness problem.
+  async getOwnRecord(collection, rkey) {
+    try {
+      const res = await this.request("com.atproto.repo.getRecord", {
+        query: { repo: this.session.did, collection, rkey },
+      });
+      return res.data;
+    } catch (error) {
+      if (error instanceof ApiError && error.data?.error === "RecordNotFound") {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async putRecord(collection, rkey, record, swapRecord) {
+    const res = await this.request("com.atproto.repo.putRecord", {
+      method: "POST",
+      body: {
+        repo: this.session.did,
+        collection,
+        rkey,
+        record,
+        swapRecord: swapRecord ?? null,
+      },
+    });
+    return res.data;
+  }
+
+  async deleteRecord(collection, rkey) {
+    const res = await this.request("com.atproto.repo.deleteRecord", {
+      method: "POST",
+      body: {
+        repo: this.session.did,
+        collection,
+        rkey,
+      },
+    });
+    return res.data;
+  }
+
   async createModerationReport({ reasonType, reason, subject, labelerDid }) {
     const body = {
       reasonType,

--- a/src/js/components/plugin-slot.js
+++ b/src/js/components/plugin-slot.js
@@ -14,9 +14,12 @@ class PluginSlot extends Component {
     if (!this.pluginService) {
       throw new Error("pluginService is required");
     }
-    if (!this.interactionHandlers) {
-      throw new Error("interactionHandlers is required");
-    }
+    // Only surfaces embedding an interactive plugin-rendered list (e.g.
+    // plugin-posts-feed/plugin-profiles-list) actually need this; slots that
+    // just render simple, non-interactive content (badges, text) have
+    // nothing to wire it to, so default it rather than force every call
+    // site to pass one.
+    this.interactionHandlers ??= {};
     this._pluginRoots = new Map();
     this._currentRequest = null;
     this._subscribe();
@@ -42,7 +45,7 @@ class PluginSlot extends Component {
 
   // TODO - automatic?
   static get observedAttributes() {
-    return ["name", "context-uri"];
+    return ["name", "context-uri", "context-did"];
   }
 
   attributeChangedCallback(name, oldValue, newValue) {

--- a/src/js/plugins/pluginLocalDataStore.js
+++ b/src/js/plugins/pluginLocalDataStore.js
@@ -1,0 +1,29 @@
+// Device-local (unsynced) storage for arbitrary plugin data — the local
+// counterpart to loadData/saveData, which round-trips through the user's
+// AT-proto preferences record and syncs across every device/session on the
+// account. Some plugin data should never leave the device it was created on
+// (e.g. a locally-held secret key a "tags"-style plugin uses to derive
+// record keys) — this is that tier. Mirrors the existing precedent in
+// pluginEndpointStore.js (device-local storage for a plugin's configured
+// network endpoint), generalized to hold arbitrary JSON rather than a
+// single URL string.
+
+const KEY_PREFIX = "improPluginLocalData:";
+
+export function getLocalData(pluginId) {
+  const raw = localStorage.getItem(KEY_PREFIX + pluginId);
+  if (raw == null) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+export function setLocalData(pluginId, data) {
+  localStorage.setItem(KEY_PREFIX + pluginId, JSON.stringify(data));
+}
+
+export function clearLocalData(pluginId) {
+  localStorage.removeItem(KEY_PREFIX + pluginId);
+}

--- a/src/js/plugins/pluginModal.js
+++ b/src/js/plugins/pluginModal.js
@@ -115,6 +115,10 @@ const ACTION_LABELS = {
     'Send feed feedback (e.g. "show fewer/more like this") on your behalf',
 };
 
+const RECORD_LABELS = {
+  write: "Create, update, and delete its own private records in your account",
+};
+
 function permissionsListTemplate({ permissions }) {
   const sections = [];
   const fetchPatterns = permissions.fetch ?? [];
@@ -137,6 +141,18 @@ function permissionsListTemplate({ permissions }) {
         <ul class="permission-prompt-list">
           ${actionScopes.map(
             (scope) => html`<li>${ACTION_LABELS[scope] ?? scope}</li>`,
+          )}
+        </ul>
+      </div>
+    `);
+  }
+  const recordScopes = permissions.records ?? [];
+  if (recordScopes.length > 0) {
+    sections.push(html`
+      <div class="permission-prompt-section">
+        <ul class="permission-prompt-list">
+          ${recordScopes.map(
+            (scope) => html`<li>${RECORD_LABELS[scope] ?? scope}</li>`,
           )}
         </ul>
       </div>

--- a/src/js/plugins/pluginPermissions.js
+++ b/src/js/plugins/pluginPermissions.js
@@ -1,6 +1,19 @@
 import { unique } from "/js/utils.js";
 
 const ACTION_SCOPES = ["mute", "block", "feedFeedback"];
+const RECORD_SCOPES = ["write"];
+
+// All records-write plugins share this one collection — a plugin doesn't
+// get to choose its own NSID. AT Protocol OAuth scopes have to name an
+// exact collection at authorization time (no partial wildcards), so
+// enumerating a new collection per plugin would mean a core change *and* a
+// forced re-authentication for every new plugin, forever. Sharing one
+// collection means the OAuth scope for it (see oauthScopes.js) only ever
+// needs to be granted once. Cross-plugin isolation within this shared
+// collection is enforced per-record by pluginService.js's putRecord/
+// deleteRecord (see the $plugin ownership marker there), not by the
+// collection name.
+export const SHARED_PLUGIN_RECORDS_COLLECTION = "social.impro.plugins.cloaca";
 
 export function getPermissionsFromManifest(manifest) {
   return parsePermissions(manifest.permissions ?? {});
@@ -26,6 +39,15 @@ export function parsePermissions(permissions) {
     );
     if (actionScopes.length > 0) parsed.actions = actionScopes;
   }
+  if (permissions.records) {
+    const recordsArray = Array.isArray(permissions.records)
+      ? permissions.records
+      : [permissions.records];
+    const recordScopes = unique(
+      recordsArray.filter((entry) => RECORD_SCOPES.includes(entry)),
+    );
+    if (recordScopes.length > 0) parsed.records = recordScopes;
+  }
   return parsed;
 }
 
@@ -33,6 +55,15 @@ export function parsePermissions(permissions) {
 // like this" feed-interaction signal)
 export function isActionAllowed(action, permissions) {
   return (permissions.actions ?? []).includes(action);
+}
+
+// Currently just "write" — lets a plugin create/update/delete its own
+// records in the shared SHARED_PLUGIN_RECORDS_COLLECTION (see
+// pluginService.js's putRecord/deleteRecord host methods). Writes are
+// always pinned to the signed-in user's own repo; a plugin never supplies
+// or chooses a repo or a collection.
+export function isRecordWriteAllowed(permissions) {
+  return (permissions.records ?? []).includes("write");
 }
 
 export function diffPermissions(current, next) {

--- a/src/js/plugins/pluginService.js
+++ b/src/js/plugins/pluginService.js
@@ -540,6 +540,30 @@ export class PluginService extends ReactiveStore {
       },
     );
 
+    this.pluginBridge.addHostMethod(
+      "listRecords",
+      async (plugin, { cursor, limit } = {}) => {
+        this._requireSignedIn();
+        this._requireRecordWritePermission(plugin);
+        const page = await this._dataLayer.api.listOwnRecords(
+          SHARED_PLUGIN_RECORDS_COLLECTION,
+          cursor,
+          limit,
+        );
+        // Other plugins' records live in this same shared collection —
+        // filter to this plugin's own before it ever reaches plugin code,
+        // the same isolation boundary putRecord/deleteRecord enforce, so a
+        // plugin can't enumerate what another plugin has stored just by
+        // declaring the same "write" scope.
+        return {
+          ...page,
+          records: (page?.records ?? []).filter(
+            (record) => record.value?.$plugin === plugin.pluginId,
+          ),
+        };
+      },
+    );
+
     this.pluginBridge.addHostMethod("getCurrentUser", () => {
       if (!this.session) return null;
       return {

--- a/src/js/plugins/pluginService.js
+++ b/src/js/plugins/pluginService.js
@@ -12,16 +12,23 @@ import {
   LocalPluginRegistry,
 } from "/js/plugins/pluginRegistry.js";
 import { PluginCache } from "/js/plugins/pluginCache.js";
+import {
+  getLocalData,
+  setLocalData,
+  clearLocalData,
+} from "/js/plugins/pluginLocalDataStore.js";
 import { PluginPreferencesManager } from "/js/plugins/pluginPreferencesManager.js";
 import { SourceProvider } from "/js/plugins/sourceProvider.js";
 import { PluginStylesLoader } from "/js/plugins/pluginStylesLoader.js";
 import { pluginFetch } from "/js/plugins/pluginRequests.js";
-import { Slingshot } from "/js/slingshot.js";
+import { Slingshot, isValidRkey } from "/js/slingshot.js";
 import {
   getPermissionsFromManifest,
   diffPermissions,
   isEmptyPermissions,
   isActionAllowed,
+  isRecordWriteAllowed,
+  SHARED_PLUGIN_RECORDS_COLLECTION,
 } from "/js/plugins/pluginPermissions.js";
 import { compareVersions, groupBy, isDev, sortBy } from "/js/utils.js";
 import {
@@ -352,12 +359,29 @@ export class PluginService extends ReactiveStore {
       await this.prefManager.writeSettingsForPlugin(plugin.pluginId, data);
     });
 
+    this.pluginBridge.addHostMethod("loadLocalData", (plugin) => {
+      return getLocalData(plugin.pluginId);
+    });
+
+    this.pluginBridge.addHostMethod("saveLocalData", (plugin, { data }) => {
+      setLocalData(plugin.pluginId, data);
+    });
+
     this.pluginBridge.addHostMethod(
       "refreshSettingTab",
       (plugin, { reset = false } = {}) => {
         this.emit("settingTabRefresh", { pluginId: plugin.pluginId, reset });
       },
     );
+
+    // Forces every mounted <plugin-slot name=...> to re-invoke its
+    // registered plugins, for slots whose content depends on data that
+    // resolved asynchronously after the initial render (e.g. a plugin that
+    // fetches something on a cache miss and wants to redraw once it lands).
+    this.pluginBridge.addHostMethod("refreshSlot", (plugin, { name }) => {
+      const current = this.$slots.get(name);
+      if (current) this.$slots.set(name, [...current]);
+    });
 
     this.pluginBridge.addHostMethod(
       "refreshFeedFilters",
@@ -454,6 +478,68 @@ export class PluginService extends ReactiveStore {
       this.slingshot.getRecord(args),
     );
 
+    this.pluginBridge.addHostMethod(
+      "putRecord",
+      async (plugin, { rkey, record }) => {
+        this._requireSignedIn();
+        this._requireRecordWritePermission(plugin);
+        requireHostMethodArg("putRecord", "rkey", rkey);
+        if (!isValidRkey(rkey)) {
+          throw new Error(`putRecord: invalid rkey "${rkey}"`);
+        }
+        requireHostMethodArg("putRecord", "record", record);
+        const existing = await this._dataLayer.api.getOwnRecord(
+          SHARED_PLUGIN_RECORDS_COLLECTION,
+          rkey,
+        );
+        if (existing && existing.value?.$plugin !== plugin.pluginId) {
+          throw new Error(
+            `putRecord: rkey "${rkey}" belongs to another plugin`,
+          );
+        }
+        return await this._dataLayer.api.putRecord(
+          SHARED_PLUGIN_RECORDS_COLLECTION,
+          rkey,
+          // $type must equal the collection it's stored in — that's an AT
+          // Protocol invariant the real PDS enforces (unlike a naive mock),
+          // so a plugin-supplied $type would always 400. Force it, same as
+          // $plugin, rather than let every plugin author discover this the
+          // hard way.
+          {
+            ...record,
+            $type: SHARED_PLUGIN_RECORDS_COLLECTION,
+            $plugin: plugin.pluginId,
+          },
+        );
+      },
+    );
+
+    this.pluginBridge.addHostMethod(
+      "deleteRecord",
+      async (plugin, { rkey }) => {
+        this._requireSignedIn();
+        this._requireRecordWritePermission(plugin);
+        requireHostMethodArg("deleteRecord", "rkey", rkey);
+        if (!isValidRkey(rkey)) {
+          throw new Error(`deleteRecord: invalid rkey "${rkey}"`);
+        }
+        const existing = await this._dataLayer.api.getOwnRecord(
+          SHARED_PLUGIN_RECORDS_COLLECTION,
+          rkey,
+        );
+        if (!existing) return;
+        if (existing.value?.$plugin !== plugin.pluginId) {
+          throw new Error(
+            `deleteRecord: rkey "${rkey}" belongs to another plugin`,
+          );
+        }
+        return await this._dataLayer.api.deleteRecord(
+          SHARED_PLUGIN_RECORDS_COLLECTION,
+          rkey,
+        );
+      },
+    );
+
     this.pluginBridge.addHostMethod("getCurrentUser", () => {
       if (!this.session) return null;
       return {
@@ -546,6 +632,12 @@ export class PluginService extends ReactiveStore {
       throw new Error(
         `"${plugin.pluginId}" does not have "${action}" action permission`,
       );
+    }
+  }
+
+  _requireRecordWritePermission(plugin) {
+    if (!isRecordWriteAllowed(plugin.permissions)) {
+      throw new Error(`"${plugin.pluginId}" does not have records permission`);
     }
   }
 
@@ -835,6 +927,7 @@ export class PluginService extends ReactiveStore {
     this.pluginBridge.unloadPlugin(pluginId);
     await this.prefManager.removeInstalledPlugin(pluginId);
     await this.prefManager.clearSettingsForPlugin(pluginId);
+    clearLocalData(pluginId);
     await this._reconcileCache(this.prefManager.$installedPlugins.get());
   }
 

--- a/src/js/slingshot.js
+++ b/src/js/slingshot.js
@@ -12,7 +12,7 @@ function isValidNsid(value) {
   return typeof value === "string" && NSID_PATTERN.test(value);
 }
 
-function isValidRkey(value) {
+export function isValidRkey(value) {
   return (
     typeof value === "string" &&
     value !== "." &&

--- a/src/js/templates/largePost.template.js
+++ b/src/js/templates/largePost.template.js
@@ -8,6 +8,7 @@ import {
 } from "/js/dataHelpers.js";
 import { avatarTemplate } from "/js/templates/avatar.template.js";
 import "/js/components/plugin-rich-text.js";
+import "/js/components/plugin-slot.js";
 import { postEmbedTemplate } from "/js/templates/postEmbed.template.js";
 import { postActionBarTemplate } from "/js/templates/postActionBar.template.js";
 import { postHeaderTextTemplate } from "/js/templates/postHeaderText.template.js";
@@ -148,6 +149,13 @@ export function largePostTemplate({
         </div>
       </div>
       ${badgeLabels.length > 0 ? labelBadgesTemplate({ badgeLabels }) : ""}
+      ${pluginService
+        ? html`<plugin-slot
+            name="author-badges"
+            context-did=${post.author?.did ?? ""}
+            .pluginService=${pluginService}
+          ></plugin-slot>`
+        : ""}
       <div class="post-content-bottom">
         ${mutedWarningTemplate({
           post,

--- a/src/js/templates/postEmbed.template.js
+++ b/src/js/templates/postEmbed.template.js
@@ -11,6 +11,7 @@ import { infoIconTemplate } from "/js/templates/icons/infoIcon.template.js";
 import { closeIconTemplate } from "/js/templates/icons/closeIcon.template.js";
 import { closeWithAnimation } from "/js/dialogHelpers.js";
 import "/js/components/plugin-rich-text.js";
+import "/js/components/plugin-slot.js";
 import { postHeaderTextTemplate } from "/js/templates/postHeaderText.template.js";
 import { labelBadgesTemplate } from "/js/templates/labelBadges.template.js";
 import { linkToPost, linkToFeed } from "/js/navigation.js";
@@ -222,6 +223,13 @@ export function quotedPostTemplate({
           </div>
           ${quotedPost.badgeLabels
             ? labelBadgesTemplate({ badgeLabels: quotedPost.badgeLabels })
+            : ""}
+          ${pluginService
+            ? html`<plugin-slot
+                name="author-badges"
+                context-did=${quotedPost.author?.did ?? ""}
+                .pluginService=${pluginService}
+              ></plugin-slot>`
             : ""}
           <div class="quoted-post-body">
             ${postText.length > 0

--- a/src/js/templates/profileCard.template.js
+++ b/src/js/templates/profileCard.template.js
@@ -24,6 +24,7 @@ import "/js/components/detected-rich-text.js";
 import { verificationBadgeTemplate } from "/js/templates/verificationBadge.template.js";
 import { automatedAccountBadgeTemplate } from "/js/templates/automatedAccountBadge.template.js";
 import { labelBadgesTemplate } from "/js/templates/labelBadges.template.js";
+import "/js/components/plugin-slot.js";
 import "/js/components/context-menu.js";
 import "/js/components/context-menu-item.js";
 import "/js/components/context-menu-item-group.js";
@@ -57,6 +58,7 @@ function profileDescriptionTemplate({
   profile,
   identityResolver,
   labelerInfo,
+  pluginService,
 }) {
   if (isBlocking) {
     return html`<div>
@@ -89,6 +91,13 @@ function profileDescriptionTemplate({
       : null}
     ${!isCurrentUser && profile.badgeLabels?.length
       ? labelBadgesTemplate({ badgeLabels: profile.badgeLabels })
+      : ""}
+    ${pluginService
+      ? html`<plugin-slot
+          name="author-badges"
+          context-did=${profile.did}
+          .pluginService=${pluginService}
+        ></plugin-slot>`
       : ""}
   `;
 }
@@ -445,6 +454,7 @@ export function profileCardTemplate({
       labelerInfo,
       profile,
       identityResolver,
+      pluginService,
     })}
   </div>`;
 }

--- a/src/js/templates/smallPost.template.js
+++ b/src/js/templates/smallPost.template.js
@@ -10,6 +10,7 @@ import { noop } from "/js/utils.js";
 import { linkToPost, linkToProfile } from "/js/navigation.js";
 import { avatarTemplate } from "/js/templates/avatar.template.js";
 import "/js/components/plugin-rich-text.js";
+import "/js/components/plugin-slot.js";
 import { postEmbedTemplate } from "/js/templates/postEmbed.template.js";
 import { postActionBarTemplate } from "/js/templates/postActionBar.template.js";
 import { postHeaderTextTemplate } from "/js/templates/postHeaderText.template.js";
@@ -143,6 +144,13 @@ export function smallPostTemplate({
           })}
           ${post.badgeLabels
             ? labelBadgesTemplate({ badgeLabels: post.badgeLabels })
+            : ""}
+          ${pluginService
+            ? html`<plugin-slot
+                name="author-badges"
+                context-did=${post.author?.did ?? ""}
+                .pluginService=${pluginService}
+              ></plugin-slot>`
             : ""}
           ${showReplyToLabel
             ? html`<div class="reply-to-author">

--- a/src/js/views/chatDetail.view.js
+++ b/src/js/views/chatDetail.view.js
@@ -23,6 +23,7 @@ import { avatarGroupTemplate } from "/js/templates/avatarGroup.template.js";
 import { verificationBadgeTemplate } from "/js/templates/verificationBadge.template.js";
 import { automatedAccountBadgeTemplate } from "/js/templates/automatedAccountBadge.template.js";
 import { labelBadgesTemplate } from "/js/templates/labelBadges.template.js";
+import "/js/components/plugin-slot.js";
 import {
   postEmbedTemplate,
   recordEmbedTemplate,
@@ -1135,6 +1136,13 @@ class ChatDetailView extends View {
           : ""}
         ${hasBadgeLabels
           ? labelBadgesTemplate({ badgeLabels: profile.badgeLabels })
+          : ""}
+        ${pluginService
+          ? html`<plugin-slot
+              name="author-badges"
+              context-did=${profile.did}
+              .pluginService=${pluginService}
+            ></plugin-slot>`
           : ""}
         <a
           class="rounded-button chat-info-panel-go-to-profile-button"

--- a/src/oauthScopes.js
+++ b/src/oauthScopes.js
@@ -142,6 +142,18 @@ const CHAT_OAUTH_RPC_SCOPES = [
 
 const CHAT_OAUTH_REPO_SCOPES = ["repo:chat.bsky.actor.declaration"];
 
+// Every plugin declaring permissions.records: ["write"] shares this single
+// collection (see SHARED_PLUGIN_RECORDS_COLLECTION in pluginPermissions.js)
+// — a plugin never gets its own collection name. AT Protocol OAuth scopes
+// must name an exact collection (no wildcards, partial or otherwise), so
+// per-plugin collections would mean adding a new scope entry here *and*
+// forcing every user to re-authenticate for every single new plugin,
+// forever. Sharing one collection means this is the only scope entry
+// records-write plugins will ever need — cross-plugin isolation is enforced
+// per-record by pluginService.js's putRecord/deleteRecord instead (see the
+// $plugin ownership marker there), not by the OAuth scope.
+const PLUGIN_OAUTH_REPO_SCOPES = ["repo:social.impro.plugins.cloaca"];
+
 const ATPROTO_OAUTH_RPC_SCOPES = [
   "rpc:com.atproto.moderation.createReport",
   "rpc:com.atproto.repo.uploadBlob",
@@ -180,6 +192,7 @@ function buildOauthScopesString() {
     ...expandScopes(ATPROTO_OAUTH_RPC_SCOPES),
     ...expandScopes(BSKY_OAUTH_REPO_SCOPES),
     ...expandScopes(CHAT_OAUTH_REPO_SCOPES),
+    ...expandScopes(PLUGIN_OAUTH_REPO_SCOPES),
     ...expandScopes(OPTIONAL_OAUTH_RPC_SCOPES),
   ];
   return scopes.join(" ");

--- a/tests/e2e/specs/flows/tagsPlugin.test.js
+++ b/tests/e2e/specs/flows/tagsPlugin.test.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { test, expect } from "../../base.js";
 import { login } from "../../helpers.js";
 import { MockServer } from "../../mockServer.js";
+import { userProfile } from "../../testData.js";
 import { createProfile } from "../../../shared/factories.js";
 
 // End-to-end coverage for the new host capabilities the "Tags" community
@@ -136,16 +137,41 @@ test.describe("Tags plugin", () => {
         });
       },
     );
+    // Backs syncFromPds — the bulk fetch that populates the local rkey
+    // index once at startup so badge rendering never needs a per-post
+    // network round trip. Counting calls lets the test prove that.
+    let listRecordsCalls = 0;
+    await page.route("**/xrpc/com.atproto.repo.listRecords*", async (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get("collection") !== SHARED_COLLECTION) {
+        return route.fallback();
+      }
+      listRecordsCalls++;
+      const records = [...tagRecords.entries()].map(([rkey, record]) => ({
+        uri: `at://${userProfile.did}/${SHARED_COLLECTION}/${rkey}`,
+        cid: "bafyfaketagcid",
+        value: record,
+      }));
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ records }),
+      });
+    });
     // Backs both the plugin-facing public getRecord bridge (used by
-    // fetchTags) and the host's own authenticated read-before-write
-    // ownership check inside putRecord/deleteRecord — both hit this same
-    // XRPC path, just against different hosts, and Playwright's route glob
-    // matches either.
+    // fetchTags, the edit modal's live per-DID lookup) and the host's own
+    // authenticated read-before-write ownership check inside putRecord/
+    // deleteRecord — both hit this same XRPC path, just against different
+    // hosts, and Playwright's route glob matches either. Counting calls
+    // lets the test prove badge rendering never triggers one of these,
+    // only the modal's own deliberate per-DID lookup does.
+    let getRecordCalls = 0;
     await page.route("**/xrpc/com.atproto.repo.getRecord*", async (route) => {
       const url = new URL(route.request().url());
       if (url.searchParams.get("collection") !== SHARED_COLLECTION) {
         return route.fallback();
       }
+      getRecordCalls++;
       const rkey = url.searchParams.get("rkey");
       const record = tagRecords.get(rkey);
       if (!record) {
@@ -234,12 +260,22 @@ test.describe("Tags plugin", () => {
     expect(record.$type).toBe(SHARED_COLLECTION);
     expect(record.$plugin).toBe(TAGS_PLUGIN_ID);
 
-    // Reloading the profile should render the tag as a badge next to the
-    // account, via the new author-badges slot.
+    // The badge should show up immediately, updated locally from the
+    // write itself — no fresh listRecords sync needed for this.
+    await expect(
+      profileView.locator(".tag-badges .tag-badge", { hasText: "friend" }),
+    ).toBeVisible({ timeout: 10000 });
+
+    // A fresh load (a new worker, empty in-memory state) has to rebuild
+    // the local index from the PDS — via one bulk listRecords sync, not a
+    // per-post/per-profile getRecord call — and still render the badge.
+    const getRecordCallsBeforeReload = getRecordCalls;
     await page.reload();
     await expect(
       profileView.locator(".tag-badges .tag-badge", { hasText: "friend" }),
     ).toBeVisible({ timeout: 10000 });
+    expect(listRecordsCalls).toBeGreaterThan(0);
+    expect(getRecordCalls).toBe(getRecordCallsBeforeReload);
 
     expect(pageErrors).toEqual([]);
   });

--- a/tests/e2e/specs/flows/tagsPlugin.test.js
+++ b/tests/e2e/specs/flows/tagsPlugin.test.js
@@ -1,0 +1,246 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test, expect } from "../../base.js";
+import { login } from "../../helpers.js";
+import { MockServer } from "../../mockServer.js";
+import { createProfile } from "../../../shared/factories.js";
+
+// End-to-end coverage for the new host capabilities the "Tags" community
+// plugin relies on:
+// - permissions.records.write consent + the putRecord/deleteRecord bridge
+// - loadLocalData/saveLocalData (device-local, unsynced plugin storage)
+// - the author-badges plugin slot rendered next to a profile
+//
+// MockServer's own plugins-local routes always serve its built-in "Test
+// Plugin" fixture (by design — "e2e tests don't depend on plugins-local/"),
+// so this test overrides those three routes after mockServer.setup() to
+// serve the real tags/ plugin's manifest and built main.js instead. That
+// keeps the plugin's actual permissions declaration (and thus the consent
+// modal copy) and actual runtime behavior under test, not a stand-in.
+// The collection every records-write plugin shares (see
+// SHARED_PLUGIN_RECORDS_COLLECTION in pluginPermissions.js) — not specific
+// to this plugin, which is exactly the point of the shared-collection
+// design (see oauthScopes.js).
+const SHARED_COLLECTION = "social.impro.plugins.cloaca";
+const TAGS_PLUGIN_ID = "tags__LOCAL";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TAGS_PLUGIN_DIR = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  "..",
+  "tags",
+);
+const tagsManifest = JSON.parse(
+  fs.readFileSync(path.join(TAGS_PLUGIN_DIR, "manifest.json"), "utf-8"),
+);
+const tagsMainSource = fs.readFileSync(
+  path.join(TAGS_PLUGIN_DIR, "main.js"),
+  "utf-8",
+);
+
+async function serveRealTagsPlugin(page) {
+  await page.route("**/plugins-local/index.json", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          id: TAGS_PLUGIN_ID,
+          name: tagsManifest.name,
+          author: tagsManifest.author,
+          description: tagsManifest.description,
+        },
+      ]),
+    }),
+  );
+  await page.route(
+    `**/plugins-local/${TAGS_PLUGIN_ID}/manifest.json`,
+    (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(tagsManifest),
+      }),
+  );
+  await page.route(`**/plugins-local/${TAGS_PLUGIN_ID}/main.js`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/javascript",
+      body: tagsMainSource,
+    }),
+  );
+}
+
+test.describe("Tags plugin", () => {
+  test("install, write a tag, and see it rendered as a badge", async ({
+    page,
+  }) => {
+    const mockServer = new MockServer();
+    const otherUser = createProfile({
+      did: "did:plc:otheruser1",
+      handle: "otheruser.bsky.social",
+      displayName: "Other User",
+      followersCount: 10,
+      followsCount: 10,
+      postsCount: 10,
+    });
+    mockServer.addProfile(otherUser);
+    await mockServer.setup(page);
+    await serveRealTagsPlugin(page);
+
+    // In-memory store for the tags collection so a putRecord followed by a
+    // getRecord round-trips like a real PDS would.
+    const tagRecords = new Map();
+    await page.route("**/xrpc/com.atproto.repo.putRecord*", async (route) => {
+      const body = route.request().postDataJSON();
+      if (body?.collection !== SHARED_COLLECTION) return route.fallback();
+      // Real PDSs reject a record whose $type doesn't match its containing
+      // collection — enforce that here too, or this mock would happily
+      // accept a bug (a mismatched $type) that only ever surfaces against a
+      // real PDS.
+      if (body.record?.$type !== SHARED_COLLECTION) {
+        return route.fulfill({
+          status: 400,
+          contentType: "application/json",
+          body: JSON.stringify({
+            error: "InvalidRequest",
+            message: `Invalid $type: expected ${SHARED_COLLECTION}, got ${body.record?.$type}`,
+          }),
+        });
+      }
+      tagRecords.set(body.rkey, body.record);
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          uri: `at://${body.repo}/${body.collection}/${body.rkey}`,
+          cid: "bafyfaketagcid",
+        }),
+      });
+    });
+    await page.route(
+      "**/xrpc/com.atproto.repo.deleteRecord*",
+      async (route) => {
+        const body = route.request().postDataJSON();
+        if (body?.collection !== SHARED_COLLECTION) return route.fallback();
+        tagRecords.delete(body.rkey);
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: "{}",
+        });
+      },
+    );
+    // Backs both the plugin-facing public getRecord bridge (used by
+    // fetchTags) and the host's own authenticated read-before-write
+    // ownership check inside putRecord/deleteRecord — both hit this same
+    // XRPC path, just against different hosts, and Playwright's route glob
+    // matches either.
+    await page.route("**/xrpc/com.atproto.repo.getRecord*", async (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get("collection") !== SHARED_COLLECTION) {
+        return route.fallback();
+      }
+      const rkey = url.searchParams.get("rkey");
+      const record = tagRecords.get(rkey);
+      if (!record) {
+        return route.fulfill({
+          status: 400,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "RecordNotFound" }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          uri: `at://x/${SHARED_COLLECTION}/${rkey}`,
+          cid: "bafyfaketagcid",
+          value: record,
+        }),
+      });
+    });
+
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err.message));
+
+    await login(page);
+
+    // Install the local Tags plugin from the community listing.
+    await page.goto("/plugins/community");
+    const community = page.locator("#community-plugins-view");
+    const tagsItem = community.locator(".plugin-list-item", {
+      hasText: "Tags",
+    });
+    await expect(tagsItem).toBeVisible({ timeout: 10000 });
+    await tagsItem.locator(".plugin-list-item-link").click();
+
+    const listing = page.locator("#community-plugin-listing-view");
+    const installButton = listing.locator(
+      '[data-testid="plugin-listing-install-button"]',
+    );
+    await expect(installButton).toHaveText("Install", { timeout: 10000 });
+    await installButton.click();
+
+    // The new records-write permission should show up in the consent modal.
+    const permissionPrompt = page.locator('[data-testid="permission-prompt"]');
+    await expect(permissionPrompt).toBeVisible({ timeout: 10000 });
+    await expect(permissionPrompt).toContainText(
+      "Create, update, and delete its own private records",
+    );
+    await page.locator('[data-testid="modal-confirm-button"]').click();
+    await expect(installButton).toHaveText("Uninstall", { timeout: 10000 });
+
+    // Add a key in the plugin's settings and mark it the display key.
+    await page.goto("/settings/plugins/tags__LOCAL");
+    const settingsView = page.locator("#settings-plugin-detail-view");
+    const settings = settingsView.locator(".setting-item");
+    await expect(settings.first()).toBeVisible({ timeout: 10000 });
+    await settings
+      .filter({ hasText: "New key label" })
+      .locator("input")
+      .fill("personal");
+    await settings.filter({ hasText: "Add key" }).locator("button").click();
+    await expect(
+      settingsView.locator(".setting-item", {
+        hasText: "Current display key",
+      }),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Visit the other user's profile and add a tag through the context menu.
+    await page.goto(`/profile/${otherUser.did}`);
+    const profileView = page.locator("#profile-view");
+    await profileView.locator(".ellipsis-button").click();
+    await page.locator("context-menu-item", { hasText: "Edit tags" }).click();
+
+    const modal = page.locator(".modal-dialog");
+    await expect(modal).toBeVisible({ timeout: 10000 });
+    await modal.locator("input.setting-item-text-input").fill("friend");
+    await modal.locator("button", { hasText: "Save" }).click();
+    await expect(modal).toBeHidden({ timeout: 10000 });
+
+    // The record should have actually been written under the shared
+    // collection, with an rkey that reveals nothing about the target DID,
+    // stamped with this plugin's own ownership marker.
+    expect(tagRecords.size).toBe(1);
+    const [[rkey, record]] = [...tagRecords.entries()];
+    expect(rkey).toMatch(/^[0-9a-f]{64}$/);
+    expect(record.tags).toEqual(["friend"]);
+    expect(record.$type).toBe(SHARED_COLLECTION);
+    expect(record.$plugin).toBe(TAGS_PLUGIN_ID);
+
+    // Reloading the profile should render the tag as a badge next to the
+    // account, via the new author-badges slot.
+    await page.reload();
+    await expect(
+      profileView.locator(".tag-badges .tag-badge", { hasText: "friend" }),
+    ).toBeVisible({ timeout: 10000 });
+
+    expect(pageErrors).toEqual([]);
+  });
+});

--- a/tests/e2e/specs/flows/tagsPlugin.test.js
+++ b/tests/e2e/specs/flows/tagsPlugin.test.js
@@ -12,6 +12,9 @@ import { createProfile } from "../../../shared/factories.js";
 // - permissions.records.write consent + the putRecord/deleteRecord bridge
 // - loadLocalData/saveLocalData (device-local, unsynced plugin storage)
 // - the author-badges plugin slot rendered next to a profile
+// - listRecords (bulk sync) and the local reverse did index it feeds, which
+//   backs "click a tag -> see everyone tagged with it" and the settings
+//   tab's "browse by tag" view
 //
 // MockServer's own plugins-local routes always serve its built-in "Test
 // Plugin" fixture (by design — "e2e tests don't depend on plugins-local/"),
@@ -77,6 +80,150 @@ async function serveRealTagsPlugin(page) {
   );
 }
 
+// In-memory store for the shared records collection, wired up so
+// putRecord/getRecord/listRecords/deleteRecord round-trip like a real PDS
+// would (including its $type-matches-collection invariant). Returns the
+// call counters the tests use to prove badge rendering stays a pure local
+// lookup (no per-post getRecord) while the bulk sync uses listRecords.
+async function mockRecordsCollection(page) {
+  const tagRecords = new Map();
+
+  await page.route("**/xrpc/com.atproto.repo.putRecord*", async (route) => {
+    const body = route.request().postDataJSON();
+    if (body?.collection !== SHARED_COLLECTION) return route.fallback();
+    // Real PDSs reject a record whose $type doesn't match its containing
+    // collection — enforce that here too, or this mock would happily
+    // accept a bug (a mismatched $type) that only ever surfaces against a
+    // real PDS.
+    if (body.record?.$type !== SHARED_COLLECTION) {
+      return route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: "InvalidRequest",
+          message: `Invalid $type: expected ${SHARED_COLLECTION}, got ${body.record?.$type}`,
+        }),
+      });
+    }
+    tagRecords.set(body.rkey, body.record);
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        uri: `at://${body.repo}/${body.collection}/${body.rkey}`,
+        cid: "bafyfaketagcid",
+      }),
+    });
+  });
+  await page.route("**/xrpc/com.atproto.repo.deleteRecord*", async (route) => {
+    const body = route.request().postDataJSON();
+    if (body?.collection !== SHARED_COLLECTION) return route.fallback();
+    tagRecords.delete(body.rkey);
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: "{}",
+    });
+  });
+  // Backs syncFromPds — the bulk fetch that populates the local rkey
+  // index once at startup so badge rendering never needs a per-post
+  // network round trip. Counting calls lets the test prove that.
+  const counters = { listRecordsCalls: 0, getRecordCalls: 0 };
+  await page.route("**/xrpc/com.atproto.repo.listRecords*", async (route) => {
+    const url = new URL(route.request().url());
+    if (url.searchParams.get("collection") !== SHARED_COLLECTION) {
+      return route.fallback();
+    }
+    counters.listRecordsCalls++;
+    const records = [...tagRecords.entries()].map(([rkey, record]) => ({
+      uri: `at://${userProfile.did}/${SHARED_COLLECTION}/${rkey}`,
+      cid: "bafyfaketagcid",
+      value: record,
+    }));
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ records }),
+    });
+  });
+  // Backs both the plugin-facing public getRecord bridge (used by
+  // fetchTags, the edit modal's live per-DID lookup) and the host's own
+  // authenticated read-before-write ownership check inside putRecord/
+  // deleteRecord — both hit this same XRPC path, just against different
+  // hosts, and Playwright's route glob matches either. Counting calls
+  // lets the test prove badge rendering never triggers one of these,
+  // only the modal's own deliberate per-DID lookup does.
+  await page.route("**/xrpc/com.atproto.repo.getRecord*", async (route) => {
+    const url = new URL(route.request().url());
+    if (url.searchParams.get("collection") !== SHARED_COLLECTION) {
+      return route.fallback();
+    }
+    counters.getRecordCalls++;
+    const rkey = url.searchParams.get("rkey");
+    const record = tagRecords.get(rkey);
+    if (!record) {
+      return route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "RecordNotFound" }),
+      });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        uri: `at://x/${SHARED_COLLECTION}/${rkey}`,
+        cid: "bafyfaketagcid",
+        value: record,
+      }),
+    });
+  });
+
+  return { tagRecords, counters };
+}
+
+// Installs the real tags/ plugin from the community listing, approves the
+// records-write consent prompt, and adds a single local key named
+// "personal" as the display key. Returns nothing — callers proceed from
+// the plugin's settings page.
+async function installTagsPluginWithKey(page) {
+  await page.goto("/plugins/community");
+  const community = page.locator("#community-plugins-view");
+  const tagsItem = community.locator(".plugin-list-item", {
+    hasText: "Tags",
+  });
+  await expect(tagsItem).toBeVisible({ timeout: 10000 });
+  await tagsItem.locator(".plugin-list-item-link").click();
+
+  const listing = page.locator("#community-plugin-listing-view");
+  const installButton = listing.locator(
+    '[data-testid="plugin-listing-install-button"]',
+  );
+  await expect(installButton).toHaveText("Install", { timeout: 10000 });
+  await installButton.click();
+
+  const permissionPrompt = page.locator('[data-testid="permission-prompt"]');
+  await expect(permissionPrompt).toBeVisible({ timeout: 10000 });
+  await expect(permissionPrompt).toContainText(
+    "Create, update, and delete its own private records",
+  );
+  await page.locator('[data-testid="modal-confirm-button"]').click();
+  await expect(installButton).toHaveText("Uninstall", { timeout: 10000 });
+
+  await page.goto("/settings/plugins/tags__LOCAL");
+  const settingsView = page.locator("#settings-plugin-detail-view");
+  const settings = settingsView.locator(".setting-item");
+  await expect(settings.first()).toBeVisible({ timeout: 10000 });
+  await settings
+    .filter({ hasText: "New key label" })
+    .locator("input")
+    .fill("personal");
+  await settings.filter({ hasText: "Add key" }).locator("button").click();
+  await expect(
+    settingsView.locator(".setting-item", { hasText: "Current display key" }),
+  ).toBeVisible({ timeout: 10000 });
+}
+
 test.describe("Tags plugin", () => {
   test("install, write a tag, and see it rendered as a badge", async ({
     page,
@@ -93,150 +240,13 @@ test.describe("Tags plugin", () => {
     mockServer.addProfile(otherUser);
     await mockServer.setup(page);
     await serveRealTagsPlugin(page);
-
-    // In-memory store for the tags collection so a putRecord followed by a
-    // getRecord round-trips like a real PDS would.
-    const tagRecords = new Map();
-    await page.route("**/xrpc/com.atproto.repo.putRecord*", async (route) => {
-      const body = route.request().postDataJSON();
-      if (body?.collection !== SHARED_COLLECTION) return route.fallback();
-      // Real PDSs reject a record whose $type doesn't match its containing
-      // collection — enforce that here too, or this mock would happily
-      // accept a bug (a mismatched $type) that only ever surfaces against a
-      // real PDS.
-      if (body.record?.$type !== SHARED_COLLECTION) {
-        return route.fulfill({
-          status: 400,
-          contentType: "application/json",
-          body: JSON.stringify({
-            error: "InvalidRequest",
-            message: `Invalid $type: expected ${SHARED_COLLECTION}, got ${body.record?.$type}`,
-          }),
-        });
-      }
-      tagRecords.set(body.rkey, body.record);
-      return route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          uri: `at://${body.repo}/${body.collection}/${body.rkey}`,
-          cid: "bafyfaketagcid",
-        }),
-      });
-    });
-    await page.route(
-      "**/xrpc/com.atproto.repo.deleteRecord*",
-      async (route) => {
-        const body = route.request().postDataJSON();
-        if (body?.collection !== SHARED_COLLECTION) return route.fallback();
-        tagRecords.delete(body.rkey);
-        return route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: "{}",
-        });
-      },
-    );
-    // Backs syncFromPds — the bulk fetch that populates the local rkey
-    // index once at startup so badge rendering never needs a per-post
-    // network round trip. Counting calls lets the test prove that.
-    let listRecordsCalls = 0;
-    await page.route("**/xrpc/com.atproto.repo.listRecords*", async (route) => {
-      const url = new URL(route.request().url());
-      if (url.searchParams.get("collection") !== SHARED_COLLECTION) {
-        return route.fallback();
-      }
-      listRecordsCalls++;
-      const records = [...tagRecords.entries()].map(([rkey, record]) => ({
-        uri: `at://${userProfile.did}/${SHARED_COLLECTION}/${rkey}`,
-        cid: "bafyfaketagcid",
-        value: record,
-      }));
-      return route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ records }),
-      });
-    });
-    // Backs both the plugin-facing public getRecord bridge (used by
-    // fetchTags, the edit modal's live per-DID lookup) and the host's own
-    // authenticated read-before-write ownership check inside putRecord/
-    // deleteRecord — both hit this same XRPC path, just against different
-    // hosts, and Playwright's route glob matches either. Counting calls
-    // lets the test prove badge rendering never triggers one of these,
-    // only the modal's own deliberate per-DID lookup does.
-    let getRecordCalls = 0;
-    await page.route("**/xrpc/com.atproto.repo.getRecord*", async (route) => {
-      const url = new URL(route.request().url());
-      if (url.searchParams.get("collection") !== SHARED_COLLECTION) {
-        return route.fallback();
-      }
-      getRecordCalls++;
-      const rkey = url.searchParams.get("rkey");
-      const record = tagRecords.get(rkey);
-      if (!record) {
-        return route.fulfill({
-          status: 400,
-          contentType: "application/json",
-          body: JSON.stringify({ error: "RecordNotFound" }),
-        });
-      }
-      return route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          uri: `at://x/${SHARED_COLLECTION}/${rkey}`,
-          cid: "bafyfaketagcid",
-          value: record,
-        }),
-      });
-    });
+    const { tagRecords, counters } = await mockRecordsCollection(page);
 
     const pageErrors = [];
     page.on("pageerror", (err) => pageErrors.push(err.message));
 
     await login(page);
-
-    // Install the local Tags plugin from the community listing.
-    await page.goto("/plugins/community");
-    const community = page.locator("#community-plugins-view");
-    const tagsItem = community.locator(".plugin-list-item", {
-      hasText: "Tags",
-    });
-    await expect(tagsItem).toBeVisible({ timeout: 10000 });
-    await tagsItem.locator(".plugin-list-item-link").click();
-
-    const listing = page.locator("#community-plugin-listing-view");
-    const installButton = listing.locator(
-      '[data-testid="plugin-listing-install-button"]',
-    );
-    await expect(installButton).toHaveText("Install", { timeout: 10000 });
-    await installButton.click();
-
-    // The new records-write permission should show up in the consent modal.
-    const permissionPrompt = page.locator('[data-testid="permission-prompt"]');
-    await expect(permissionPrompt).toBeVisible({ timeout: 10000 });
-    await expect(permissionPrompt).toContainText(
-      "Create, update, and delete its own private records",
-    );
-    await page.locator('[data-testid="modal-confirm-button"]').click();
-    await expect(installButton).toHaveText("Uninstall", { timeout: 10000 });
-
-    // Add a key in the plugin's settings and mark it the display key.
-    await page.goto("/settings/plugins/tags__LOCAL");
-    const settingsView = page.locator("#settings-plugin-detail-view");
-    const settings = settingsView.locator(".setting-item");
-    await expect(settings.first()).toBeVisible({ timeout: 10000 });
-    await settings
-      .filter({ hasText: "New key label" })
-      .locator("input")
-      .fill("personal");
-    await settings.filter({ hasText: "Add key" }).locator("button").click();
-    await expect(
-      settingsView.locator(".setting-item", {
-        hasText: "Current display key",
-      }),
-    ).toBeVisible({ timeout: 10000 });
+    await installTagsPluginWithKey(page);
 
     // Visit the other user's profile and add a tag through the context menu.
     await page.goto(`/profile/${otherUser.did}`);
@@ -269,13 +279,120 @@ test.describe("Tags plugin", () => {
     // A fresh load (a new worker, empty in-memory state) has to rebuild
     // the local index from the PDS — via one bulk listRecords sync, not a
     // per-post/per-profile getRecord call — and still render the badge.
-    const getRecordCallsBeforeReload = getRecordCalls;
+    const getRecordCallsBeforeReload = counters.getRecordCalls;
     await page.reload();
     await expect(
       profileView.locator(".tag-badges .tag-badge", { hasText: "friend" }),
     ).toBeVisible({ timeout: 10000 });
-    expect(listRecordsCalls).toBeGreaterThan(0);
-    expect(getRecordCalls).toBe(getRecordCallsBeforeReload);
+    expect(counters.listRecordsCalls).toBeGreaterThan(0);
+    expect(counters.getRecordCalls).toBe(getRecordCallsBeforeReload);
+
+    expect(pageErrors).toEqual([]);
+  });
+
+  test("clicking a badge and browsing by tag both show the tagged account, and support editing/removing from there", async ({
+    page,
+  }) => {
+    const mockServer = new MockServer();
+    const otherUser = createProfile({
+      did: "did:plc:otheruser1",
+      handle: "otheruser.bsky.social",
+      displayName: "Other User",
+      followersCount: 10,
+      followsCount: 10,
+      postsCount: 10,
+    });
+    mockServer.addProfile(otherUser);
+    await mockServer.setup(page);
+    await serveRealTagsPlugin(page);
+    await mockRecordsCollection(page);
+
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err.message));
+
+    await login(page);
+    await installTagsPluginWithKey(page);
+
+    await page.goto(`/profile/${otherUser.did}`);
+    const profileView = page.locator("#profile-view");
+    await profileView.locator(".ellipsis-button").click();
+    await page.locator("context-menu-item", { hasText: "Edit tags" }).click();
+    const editModal = page.locator(".modal-dialog");
+    await expect(editModal).toBeVisible({ timeout: 10000 });
+    await editModal.locator("input.setting-item-text-input").fill("friend");
+    await editModal.locator("button", { hasText: "Save" }).click();
+    await expect(editModal).toBeHidden({ timeout: 10000 });
+
+    const badge = profileView.locator(".tag-badges .tag-badge", {
+      hasText: "friend",
+    });
+    await expect(badge).toBeVisible({ timeout: 10000 });
+
+    // Clicking the badge should open a list of everyone tagged "friend"
+    // under the current display key, including the account we just tagged.
+    await badge.click();
+    // Scope to the currently open dialog — the just-closed edit modal is
+    // still in the DOM (hidden, no [open] attribute), and a plain
+    // ".modal-dialog" locator would match both.
+    const listModal = page.locator(".modal-dialog[open]");
+    await expect(listModal).toBeVisible({ timeout: 10000 });
+    await expect(listModal).toContainText("friend");
+    await expect(listModal.locator(".tag-list-row")).toHaveCount(1);
+    await expect(listModal.locator(".tag-list-row")).toContainText(
+      "Other User",
+    );
+
+    // Editing from the list should reach the same edit modal, prefilled.
+    await listModal.locator("button", { hasText: "Edit" }).click();
+    const editFromList = page.locator(".modal-dialog[open]");
+    await expect(editFromList).toBeVisible({ timeout: 10000 });
+    await expect(
+      editFromList.locator("input.setting-item-text-input"),
+    ).toHaveValue("friend");
+    await editFromList.locator("button", { hasText: "Cancel" }).click();
+    await expect(editFromList).toBeHidden({ timeout: 10000 });
+
+    // The settings tab's own "Browse by tag" view should find the same
+    // account for the same key + tag.
+    await page.goto("/settings/plugins/tags__LOCAL");
+    const settingsView = page.locator("#settings-plugin-detail-view");
+    await expect(settingsView).toContainText("Browse by tag", {
+      timeout: 10000,
+    });
+    // The "Display key" setting's own description also mentions "tags", so
+    // match the Tag row by its exact setting name rather than substring
+    // text anywhere in the row.
+    const tagRow = settingsView
+      .locator(".setting-item")
+      .filter({
+        has: page.locator(".setting-item-name", { hasText: /^Tag$/ }),
+      });
+    await tagRow.locator("select").selectOption("friend");
+    await tagRow.locator("button", { hasText: "View" }).click();
+
+    const browseModal = page.locator(".modal-dialog[open]");
+    await expect(browseModal).toBeVisible({ timeout: 10000 });
+    await expect(browseModal.locator(".tag-list-row")).toHaveCount(1);
+    await expect(browseModal.locator(".tag-list-row")).toContainText(
+      "Other User",
+    );
+
+    // Removing the tag from the browse list should clear the badge back
+    // on the profile. The Remove handler closes this modal and reopens a
+    // fresh one (Modal has no live re-render), so re-query the open dialog.
+    await browseModal.locator("button", { hasText: 'Remove "friend"' }).click();
+    const reopenedModal = page.locator(".modal-dialog[open]");
+    await expect(reopenedModal.locator(".tag-list-row")).toHaveCount(0, {
+      timeout: 10000,
+    });
+    await reopenedModal.locator("button", { hasText: "Close" }).click();
+
+    await page.goto(`/profile/${otherUser.did}`);
+    await expect(
+      page.locator("#profile-view .tag-badges .tag-badge", {
+        hasText: "friend",
+      }),
+    ).toHaveCount(0, { timeout: 10000 });
 
     expect(pageErrors).toEqual([]);
   });

--- a/tests/unit/specs/components/plugin-slot.test.js
+++ b/tests/unit/specs/components/plugin-slot.test.js
@@ -256,12 +256,85 @@ describe("plugin-slot", () => {
       assert.deepEqual(captured, ["at://one", "at://two"]);
       assert.deepEqual(slot.children[0].textContent, "at://two");
     });
+
+    it("re-renders when context-did changes on an existing element", async () => {
+      const captured = [];
+      const pluginService = makePluginService({
+        entries: {
+          "author-badges": [
+            {
+              pluginId: "alpha",
+              invoke: async (context) => {
+                captured.push(context.did);
+                return { tag: "div", text: context.did };
+              },
+            },
+          ],
+        },
+      });
+      const slot = makeSlot({
+        pluginService,
+        name: "author-badges",
+        context: { did: "did:plc:one" },
+      });
+      document.body.appendChild(slot);
+      await flushMicrotasks();
+      assert.deepEqual(captured, ["did:plc:one"]);
+
+      slot.setAttribute("context-did", "did:plc:two");
+      await flushMicrotasks();
+      assert.deepEqual(captured, ["did:plc:one", "did:plc:two"]);
+      assert.deepEqual(slot.children[0].textContent, "did:plc:two");
+    });
+
+    it("supports multiple simultaneous instances of the same slot name, each with its own context", async () => {
+      const captured = [];
+      const pluginService = makePluginService({
+        entries: {
+          "author-badges": [
+            {
+              pluginId: "alpha",
+              invoke: async (context) => {
+                captured.push(context.did);
+                return { tag: "div", text: context.did };
+              },
+            },
+          ],
+        },
+      });
+      const slotOne = makeSlot({
+        pluginService,
+        name: "author-badges",
+        context: { did: "did:plc:one" },
+      });
+      const slotTwo = makeSlot({
+        pluginService,
+        name: "author-badges",
+        context: { did: "did:plc:two" },
+      });
+      document.body.appendChild(slotOne);
+      document.body.appendChild(slotTwo);
+      await flushMicrotasks();
+      assert.deepEqual(
+        new Set(captured),
+        new Set(["did:plc:one", "did:plc:two"]),
+      );
+      assert.deepEqual(slotOne.children[0].textContent, "did:plc:one");
+      assert.deepEqual(slotTwo.children[0].textContent, "did:plc:two");
+    });
   });
 
   describe("PluginSlot - interactionHandlers", () => {
-    it("throws when interactionHandlers is not set", () => {
+    it("defaults to an empty object when not set, rather than throwing", () => {
       const element = document.createElement("plugin-slot");
       element.pluginService = makePluginService();
+      element.setAttribute("name", "x");
+      element.connectedCallback();
+      assert.deepEqual(element.interactionHandlers, {});
+    });
+
+    it("throws when pluginService is not set", () => {
+      const element = document.createElement("plugin-slot");
       element.setAttribute("name", "x");
       let caught = null;
       try {
@@ -270,7 +343,7 @@ describe("plugin-slot", () => {
         caught = error;
       }
       assert(caught instanceof Error);
-      assert.deepEqual(caught.message, "interactionHandlers is required");
+      assert.deepEqual(caught.message, "pluginService is required");
     });
   });
 

--- a/tests/unit/specs/components/post-composer.test.js
+++ b/tests/unit/specs/components/post-composer.test.js
@@ -43,6 +43,9 @@ describe("post-composer", () => {
       $richTextTransformsVersion: { get: () => 0 },
       transformRichTextTokens: async () => null,
       renderRichTextNodeToken: () => null,
+      getClaimedFacetTypes: () => new Set(),
+      $slots: { get: () => null },
+      getSlotEntries: () => [],
     };
     return element;
   }

--- a/tests/unit/specs/plugins/pluginLocalDataStore.test.js
+++ b/tests/unit/specs/plugins/pluginLocalDataStore.test.js
@@ -1,0 +1,53 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  getLocalData,
+  setLocalData,
+  clearLocalData,
+} from "/js/plugins/pluginLocalDataStore.js";
+
+describe("pluginLocalDataStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns null when nothing has been stored", () => {
+    assert.deepEqual(getLocalData("a"), null);
+  });
+
+  it("round-trips arbitrary JSON data", () => {
+    const data = { keys: [{ id: "k1", label: "personal", secret: "shh" }] };
+    setLocalData("a", data);
+    assert.deepEqual(getLocalData("a"), data);
+  });
+
+  it("isolates data between plugin ids", () => {
+    setLocalData("a", { value: 1 });
+    setLocalData("b", { value: 2 });
+    assert.deepEqual(getLocalData("a"), { value: 1 });
+    assert.deepEqual(getLocalData("b"), { value: 2 });
+  });
+
+  it("clearLocalData removes only that plugin's entry", () => {
+    setLocalData("a", { value: 1 });
+    setLocalData("b", { value: 2 });
+    clearLocalData("a");
+    assert.deepEqual(getLocalData("a"), null);
+    assert.deepEqual(getLocalData("b"), { value: 2 });
+  });
+
+  it("overwrites previously stored data", () => {
+    setLocalData("a", { value: 1 });
+    setLocalData("a", { value: 2 });
+    assert.deepEqual(getLocalData("a"), { value: 2 });
+  });
+
+  it("returns null instead of throwing on corrupted stored data", () => {
+    localStorage.setItem("improPluginLocalData:a", "{not json");
+    assert.deepEqual(getLocalData("a"), null);
+  });
+
+  it("clearLocalData is a no-op when nothing was stored", () => {
+    assert.doesNotThrow(() => clearLocalData("never-stored"));
+  });
+});

--- a/tests/unit/specs/plugins/pluginPermissions.test.js
+++ b/tests/unit/specs/plugins/pluginPermissions.test.js
@@ -6,6 +6,7 @@ import {
   isEmptyPermissions,
   isFetchAllowed,
   isActionAllowed,
+  isRecordWriteAllowed,
 } from "/js/plugins/pluginPermissions.js";
 
 describe("parsePermissions", () => {
@@ -60,6 +61,46 @@ describe("parsePermissions", () => {
   it("omits the actions key when no valid scopes remain", () => {
     assert.deepEqual(parsePermissions({ actions: [] }), {});
     assert.deepEqual(parsePermissions({ actions: ["feedback"] }), {});
+  });
+
+  it("parses the write record scope", () => {
+    assert.deepEqual(parsePermissions({ records: ["write"] }), {
+      records: ["write"],
+    });
+  });
+
+  it("wraps a string records value into an array", () => {
+    assert.deepEqual(parsePermissions({ records: "write" }), {
+      records: ["write"],
+    });
+  });
+
+  it("filters out unknown record scopes", () => {
+    assert.deepEqual(
+      parsePermissions({ records: ["write", "delete", "read"] }),
+      { records: ["write"] },
+    );
+  });
+
+  it("dedupes records entries", () => {
+    assert.deepEqual(parsePermissions({ records: ["write", "write"] }), {
+      records: ["write"],
+    });
+  });
+
+  it("omits the records key when no valid scopes remain", () => {
+    assert.deepEqual(parsePermissions({ records: [] }), {});
+    assert.deepEqual(parsePermissions({ records: ["delete"] }), {});
+  });
+});
+
+describe("isRecordWriteAllowed", () => {
+  it("allows write when granted", () => {
+    assert(isRecordWriteAllowed({ records: ["write"] }));
+  });
+
+  it("denies everything when the records key is missing", () => {
+    assert(!isRecordWriteAllowed({}));
   });
 });
 
@@ -135,6 +176,19 @@ describe("diffPermissions", () => {
       null,
     );
   });
+
+  it("treats a missing current records key as 'everything new'", () => {
+    assert.deepEqual(diffPermissions({}, { records: ["write"] }), {
+      records: ["write"],
+    });
+  });
+
+  it("returns null when records has no new entries", () => {
+    assert.deepEqual(
+      diffPermissions({ records: ["write"] }, { records: ["write"] }),
+      null,
+    );
+  });
 });
 
 describe("isEmptyPermissions (missing-key shape)", () => {
@@ -150,6 +204,14 @@ describe("isEmptyPermissions", () => {
 
   it("returns false when any array is non-empty", () => {
     assert(!isEmptyPermissions({ fetch: ["https://a.com/*"] }));
+  });
+
+  it("returns true when records is empty", () => {
+    assert(isEmptyPermissions({ records: [] }));
+  });
+
+  it("returns false when records is non-empty", () => {
+    assert(!isEmptyPermissions({ records: ["write"] }));
   });
 });
 

--- a/tests/unit/specs/plugins/pluginService.test.js
+++ b/tests/unit/specs/plugins/pluginService.test.js
@@ -4,9 +4,14 @@ import {
   PluginService,
   PermissionsDeclinedError,
 } from "/js/plugins/pluginService.js";
+import { SHARED_PLUGIN_RECORDS_COLLECTION } from "/js/plugins/pluginPermissions.js";
 import { Signal, SignalMap } from "/js/signals.js";
 import { EventEmitter } from "/js/eventEmitter.js";
 import { HiddenFeedItemsStore } from "/js/dataLayer/hiddenFeedItemsStore.js";
+import {
+  getLocalData,
+  setLocalData,
+} from "/js/plugins/pluginLocalDataStore.js";
 import { respondToConfirm } from "../../testHelpers.js";
 
 function emptyDataLayer() {
@@ -613,6 +618,17 @@ describe("uninstallPlugin", () => {
     // Cache should be reconciled against the remaining plugin only
     assert.deepEqual(reconcileCalls.length, 1);
     assert.deepEqual(reconcileCalls[0], ["https://cache.test/b/1.0.0/ow/b"]);
+  });
+
+  it("also clears device-local plugin data", async () => {
+    const { service, state } = makeService();
+    state.installedPlugins = [
+      { id: "a", version: "1.0.0", repo: "ow/a", enabled: true },
+    ];
+    setLocalData("a", { keys: [{ id: "k1", secret: "shh" }] });
+    assert.notDeepEqual(getLocalData("a"), null);
+    await service.uninstallPlugin("a");
+    assert.deepEqual(getLocalData("a"), null);
   });
 });
 
@@ -1432,6 +1448,62 @@ describe("slot registry", () => {
   });
 });
 
+describe("refreshSlot host method", () => {
+  function makeServiceWithRealBridge() {
+    const { provider } = makeProvider();
+    return new PluginService(
+      provider,
+      null,
+      emptyDataLayer(),
+      new HiddenFeedItemsStore(),
+    );
+  }
+
+  function register(service, plugin, message) {
+    const handler = service.pluginBridge._registrationTargets.get("slot");
+    return handler(plugin, message);
+  }
+
+  function getHandler(service, name) {
+    return service.pluginBridge._hostCallHandlers.get(name);
+  }
+
+  it("triggers effects watching $slots for that name without changing its entries", () => {
+    const service = makeServiceWithRealBridge();
+    register(
+      service,
+      { pluginId: "alpha", call: () => {} },
+      {
+        target: "slot",
+        name: "author-badges",
+        handlerId: 1,
+      },
+    );
+    const before = service.$slots.get("author-badges");
+    getHandler(service, "refreshSlot")(
+      { pluginId: "alpha" },
+      { name: "author-badges" },
+    );
+    const after = service.$slots.get("author-badges");
+    assert.notEqual(before, after);
+    assert.deepEqual(
+      after.map((entry) => entry.pluginId),
+      before.map((entry) => entry.pluginId),
+    );
+  });
+
+  it("is a no-op for a slot name nobody has registered", () => {
+    const service = makeServiceWithRealBridge();
+    assert.doesNotThrow(() =>
+      getHandler(service, "refreshSlot")(
+        { pluginId: "alpha" },
+        { name: "nope" },
+      ),
+    );
+    assert.deepEqual(service.$slots.get("nope"), null);
+  });
+});
+
 describe("app.data host methods", () => {
   function makeStubComputedMap(lookup) {
     const calls = [];
@@ -1936,6 +2008,261 @@ describe("getRecord host method", () => {
       );
     }
     assert.deepEqual(fetched, false);
+  });
+});
+
+describe("putRecord/deleteRecord host methods", () => {
+  const VALID_RKEY = "abc123";
+  const plugin = { pluginId: "tags", permissions: { records: ["write"] } };
+
+  function makeService({
+    session = { did: "did:plc:me", handle: "me.test" },
+    existingRecords = {},
+  } = {}) {
+    const { provider } = makeProvider();
+    const calls = { get: [], put: [], delete: [] };
+    const store = new Map(Object.entries(existingRecords));
+    const dataLayer = Object.assign(new EventEmitter(), {
+      dataStore: { $feeds: new SignalMap() },
+      api: {
+        getOwnRecord: async (collection, rkey) => {
+          calls.get.push([collection, rkey]);
+          const value = store.get(rkey);
+          return value
+            ? { uri: `at://x/${collection}/${rkey}`, cid: "bafyx", value }
+            : null;
+        },
+        putRecord: async (collection, rkey, record) => {
+          calls.put.push([collection, rkey, record]);
+          store.set(rkey, record);
+          return { uri: `at://${session?.did}/${collection}/${rkey}` };
+        },
+        deleteRecord: async (collection, rkey) => {
+          calls.delete.push([collection, rkey]);
+          store.delete(rkey);
+        },
+      },
+    });
+    const service = new PluginService(
+      provider,
+      session,
+      dataLayer,
+      new HiddenFeedItemsStore(),
+    );
+    return { service, calls };
+  }
+
+  function getHandler(service, name) {
+    return service.pluginBridge._hostCallHandlers.get(name);
+  }
+
+  it("putRecord writes to the shared collection, stamping $plugin and $type", async () => {
+    const { service, calls } = makeService();
+    const record = { tags: ["a"] };
+    await getHandler(service, "putRecord")(plugin, {
+      rkey: VALID_RKEY,
+      record,
+    });
+    assert.deepEqual(calls.put, [
+      [
+        SHARED_PLUGIN_RECORDS_COLLECTION,
+        VALID_RKEY,
+        {
+          ...record,
+          $type: SHARED_PLUGIN_RECORDS_COLLECTION,
+          $plugin: "tags",
+        },
+      ],
+    ]);
+  });
+
+  it("overrides a plugin-supplied $type — AT Protocol requires it to equal the collection", async () => {
+    const { service, calls } = makeService();
+    await getHandler(service, "putRecord")(plugin, {
+      rkey: VALID_RKEY,
+      record: { $type: "social.impro.plugins.tags", tags: ["a"] },
+    });
+    assert.deepEqual(calls.put[0][2].$type, SHARED_PLUGIN_RECORDS_COLLECTION);
+  });
+
+  it("does not let a plugin spoof another plugin's ownership marker", async () => {
+    const { service, calls } = makeService();
+    await getHandler(service, "putRecord")(plugin, {
+      rkey: VALID_RKEY,
+      record: { $plugin: "somebody-else", tags: ["a"] },
+    });
+    assert.deepEqual(calls.put[0][2].$plugin, "tags");
+  });
+
+  it("allows overwriting a record the same plugin already owns", async () => {
+    const { service, calls } = makeService({
+      existingRecords: { [VALID_RKEY]: { $plugin: "tags", tags: ["old"] } },
+    });
+    const record = { tags: ["new"] };
+    await getHandler(service, "putRecord")(plugin, {
+      rkey: VALID_RKEY,
+      record,
+    });
+    assert.deepEqual(calls.put, [
+      [
+        SHARED_PLUGIN_RECORDS_COLLECTION,
+        VALID_RKEY,
+        {
+          ...record,
+          $type: SHARED_PLUGIN_RECORDS_COLLECTION,
+          $plugin: "tags",
+        },
+      ],
+    ]);
+  });
+
+  it("rejects putRecord when the rkey already belongs to a different plugin", async () => {
+    const { service, calls } = makeService({
+      existingRecords: { [VALID_RKEY]: { $plugin: "other-plugin" } },
+    });
+    await assert.rejects(
+      getHandler(service, "putRecord")(plugin, {
+        rkey: VALID_RKEY,
+        record: {},
+      }),
+      /belongs to another plugin/,
+    );
+    assert.deepEqual(calls.put, []);
+  });
+
+  it("deleteRecord removes a record the caller owns", async () => {
+    const { service, calls } = makeService({
+      existingRecords: { [VALID_RKEY]: { $plugin: "tags" } },
+    });
+    await getHandler(service, "deleteRecord")(plugin, { rkey: VALID_RKEY });
+    assert.deepEqual(calls.delete, [
+      [SHARED_PLUGIN_RECORDS_COLLECTION, VALID_RKEY],
+    ]);
+  });
+
+  it("deleteRecord is a no-op when the rkey doesn't exist", async () => {
+    const { service, calls } = makeService();
+    await getHandler(service, "deleteRecord")(plugin, { rkey: VALID_RKEY });
+    assert.deepEqual(calls.delete, []);
+  });
+
+  it("rejects deleteRecord when the rkey belongs to a different plugin", async () => {
+    const { service, calls } = makeService({
+      existingRecords: { [VALID_RKEY]: { $plugin: "other-plugin" } },
+    });
+    await assert.rejects(
+      getHandler(service, "deleteRecord")(plugin, { rkey: VALID_RKEY }),
+      /belongs to another plugin/,
+    );
+    assert.deepEqual(calls.delete, []);
+  });
+
+  it("rejects when the plugin doesn't have records write permission", async () => {
+    const { service, calls } = makeService();
+    const noPermissionPlugin = { pluginId: "tags", permissions: {} };
+    await assert.rejects(
+      getHandler(service, "putRecord")(noPermissionPlugin, {
+        rkey: VALID_RKEY,
+        record: {},
+      }),
+      /records permission/,
+    );
+    await assert.rejects(
+      getHandler(service, "deleteRecord")(noPermissionPlugin, {
+        rkey: VALID_RKEY,
+      }),
+      /records permission/,
+    );
+    assert.deepEqual(calls.put, []);
+    assert.deepEqual(calls.delete, []);
+  });
+
+  it("rejects an invalid rkey without calling the API", async () => {
+    const { service, calls } = makeService();
+    await assert.rejects(
+      getHandler(service, "putRecord")(plugin, {
+        rkey: "has/slash",
+        record: {},
+      }),
+      /invalid rkey/,
+    );
+    await assert.rejects(
+      getHandler(service, "deleteRecord")(plugin, { rkey: "" }),
+      /requires a rkey/,
+    );
+    assert.deepEqual(calls.get, []);
+    assert.deepEqual(calls.put, []);
+    assert.deepEqual(calls.delete, []);
+  });
+
+  it("putRecord requires a record argument", async () => {
+    const { service, calls } = makeService();
+    await assert.rejects(
+      getHandler(service, "putRecord")(plugin, { rkey: VALID_RKEY }),
+      /requires a record/,
+    );
+    assert.deepEqual(calls.put, []);
+  });
+
+  it("rejects when signed out", async () => {
+    const { service, calls } = makeService({ session: null });
+    await assert.rejects(
+      getHandler(service, "putRecord")(plugin, {
+        rkey: VALID_RKEY,
+        record: {},
+      }),
+      /Not signed in/,
+    );
+    await assert.rejects(
+      getHandler(service, "deleteRecord")(plugin, { rkey: VALID_RKEY }),
+      /Not signed in/,
+    );
+    assert.deepEqual(calls.put, []);
+    assert.deepEqual(calls.delete, []);
+  });
+});
+
+describe("loadLocalData/saveLocalData host methods", () => {
+  function makeServiceWithRealBridge() {
+    const { provider } = makeProvider();
+    return new PluginService(
+      provider,
+      null,
+      emptyDataLayer(),
+      new HiddenFeedItemsStore(),
+    );
+  }
+
+  function getHandler(service, name) {
+    return service.pluginBridge._hostCallHandlers.get(name);
+  }
+
+  const plugin = { pluginId: "tags", permissions: {} };
+
+  it("returns null before anything has been saved", () => {
+    const service = makeServiceWithRealBridge();
+    assert.deepEqual(getHandler(service, "loadLocalData")(plugin), null);
+  });
+
+  it("round-trips data through saveLocalData/loadLocalData", () => {
+    const service = makeServiceWithRealBridge();
+    const data = { keys: [{ id: "k1", label: "personal", secret: "shh" }] };
+    getHandler(service, "saveLocalData")(plugin, { data });
+    assert.deepEqual(getHandler(service, "loadLocalData")(plugin), data);
+  });
+
+  it("isolates data between plugins", () => {
+    const service = makeServiceWithRealBridge();
+    getHandler(service, "saveLocalData")(plugin, { data: { a: 1 } });
+    getHandler(service, "saveLocalData")(
+      { pluginId: "other", permissions: {} },
+      { data: { a: 2 } },
+    );
+    assert.deepEqual(getHandler(service, "loadLocalData")(plugin), { a: 1 });
+    assert.deepEqual(
+      getHandler(service, "loadLocalData")({ pluginId: "other" }),
+      { a: 2 },
+    );
   });
 });
 

--- a/tests/unit/specs/plugins/pluginService.test.js
+++ b/tests/unit/specs/plugins/pluginService.test.js
@@ -2222,6 +2222,101 @@ describe("putRecord/deleteRecord host methods", () => {
   });
 });
 
+describe("listRecords host method", () => {
+  const plugin = { pluginId: "tags", permissions: { records: ["write"] } };
+
+  function makeService({
+    session = { did: "did:plc:me", handle: "me.test" },
+    page = { cursor: undefined, records: [] },
+  } = {}) {
+    const { provider } = makeProvider();
+    const calls = { list: [] };
+    const dataLayer = Object.assign(new EventEmitter(), {
+      dataStore: { $feeds: new SignalMap() },
+      api: {
+        listOwnRecords: async (collection, cursor, limit) => {
+          calls.list.push([collection, cursor, limit]);
+          return page;
+        },
+      },
+    });
+    const service = new PluginService(
+      provider,
+      session,
+      dataLayer,
+      new HiddenFeedItemsStore(),
+    );
+    return { service, calls };
+  }
+
+  function getHandler(service, name) {
+    return service.pluginBridge._hostCallHandlers.get(name);
+  }
+
+  it("passes cursor/limit through and returns the page", async () => {
+    const page = {
+      cursor: "next-page",
+      records: [
+        {
+          uri: "at://did:plc:me/social.impro.plugins.cloaca/abc",
+          value: { $plugin: "tags", tags: ["a"] },
+        },
+      ],
+    };
+    const { service, calls } = makeService({ page });
+    const result = await getHandler(service, "listRecords")(plugin, {
+      cursor: "prev-page",
+      limit: 50,
+    });
+    assert.deepEqual(calls.list, [
+      [SHARED_PLUGIN_RECORDS_COLLECTION, "prev-page", 50],
+    ]);
+    assert.deepEqual(result, page);
+  });
+
+  it("filters out records stamped with a different plugin's id", async () => {
+    const page = {
+      cursor: undefined,
+      records: [
+        {
+          uri: "at://did:plc:me/social.impro.plugins.cloaca/mine",
+          value: { $plugin: "tags", tags: ["a"] },
+        },
+        {
+          uri: "at://did:plc:me/social.impro.plugins.cloaca/theirs",
+          value: { $plugin: "other-plugin", notes: "unrelated" },
+        },
+      ],
+    };
+    const { service } = makeService({ page });
+    const result = await getHandler(service, "listRecords")(plugin, {});
+    assert.deepEqual(result.records.length, 1);
+    assert.deepEqual(
+      result.records[0].uri,
+      "at://did:plc:me/social.impro.plugins.cloaca/mine",
+    );
+  });
+
+  it("rejects when the plugin doesn't have records write permission", async () => {
+    const { service, calls } = makeService();
+    const noPermissionPlugin = { pluginId: "tags", permissions: {} };
+    await assert.rejects(
+      getHandler(service, "listRecords")(noPermissionPlugin, {}),
+      /records permission/,
+    );
+    assert.deepEqual(calls.list, []);
+  });
+
+  it("rejects when signed out", async () => {
+    const { service, calls } = makeService({ session: null });
+    await assert.rejects(
+      getHandler(service, "listRecords")(plugin, {}),
+      /Not signed in/,
+    );
+    assert.deepEqual(calls.list, []);
+  });
+});
+
 describe("loadLocalData/saveLocalData host methods", () => {
   function makeServiceWithRealBridge() {
     const { provider } = makeProvider();

--- a/tests/unit/specs/templates/largePost.template.test.js
+++ b/tests/unit/specs/templates/largePost.template.test.js
@@ -24,6 +24,8 @@ const pluginService = {
   transformRichTextTokens: async () => null,
   renderRichTextNodeToken: () => null,
   getClaimedFacetTypes: () => new Set(),
+  $slots: { get: () => null },
+  getSlotEntries: () => [],
 };
 
 const baseProps = {

--- a/tests/unit/specs/templates/postEmbed.template.test.js
+++ b/tests/unit/specs/templates/postEmbed.template.test.js
@@ -12,6 +12,8 @@ const pluginService = {
   transformRichTextTokens: async () => null,
   renderRichTextNodeToken: () => null,
   getClaimedFacetTypes: () => new Set(),
+  $slots: { get: () => null },
+  getSlotEntries: () => [],
 };
 
 describe("postEmbedTemplate - images", () => {

--- a/tests/unit/specs/templates/smallPost.template.test.js
+++ b/tests/unit/specs/templates/smallPost.template.test.js
@@ -24,6 +24,8 @@ const pluginService = {
   transformRichTextTokens: async () => null,
   renderRichTextNodeToken: () => null,
   getClaimedFacetTypes: () => new Set(),
+  $slots: { get: () => null },
+  getSlotEntries: () => [],
 };
 
 const baseProps = {


### PR DESCRIPTION
This is what I had in mind for how to grant plugins write access to a collection in atproto.
The other options were:
- request `repo:*` and then control access through core on application level (seems bad)
- scan plugin manifests to generate oauth scopes from the actually required collections, this creates a hard dependency on cloudflare (also bad)

https://tangled.org/7778777.online/tags this plugin is how the tags would have worked, but I suppose it's better to use the preferences for this