### PR TITLE
Add a device-local (unsynced) storage tier for plugin settings

### DIFF
--- a/impro-plugin/main.js
+++ b/impro-plugin/main.js
@@ -325,6 +325,18 @@ export class Plugin {
     await hostCall("saveData", { data });
   }
 
+  // Device-local counterpart to loadData/saveData: never synced through the
+  // user's account preferences, so it's the right place for anything that
+  // shouldn't silently follow the plugin to another device (e.g. a locally
+  // held secret key). Cleared on uninstall, same as loadData/saveData.
+  async loadLocalData() {
+    return hostCall("loadLocalData");
+  }
+
+  async saveLocalData(data) {
+    await hostCall("saveLocalData", { data });
+  }
+
   addSettingTab(tab) {
     tab.plugin = this;
     const displayHandlerId = uuid.create();

--- a/plugins.md
+++ b/plugins.md
@@ -40,6 +40,10 @@ Plugins are currently in **beta** as the API surface is being expanded. However,
 - Make whitelisted network requests (requires permissions)
 - Read appview data with the current user as the viewer (profiles, posts, etc.)
 - Mute, block, or send feed feedback ("show more/less like this") on the user's behalf (requires permissions)
+- Store plugin settings on a user's account (synced across devices, via `loadData`/`saveData`)
+  or purely on the current device (never synced, via `loadLocalData`/`saveLocalData` —
+  intended for secrets or device-specific values a plugin shouldn't silently propagate,
+  e.g. a locally-held key)
 
 ### Plugins CANNOT:
 

--- a/plugins.md
+++ b/plugins.md
@@ -40,10 +40,7 @@ Plugins are currently in **beta** as the API surface is being expanded. However,
 - Make whitelisted network requests (requires permissions)
 - Read appview data with the current user as the viewer (profiles, posts, etc.)
 - Mute, block, or send feed feedback ("show more/less like this") on the user's behalf (requires permissions)
-- Store plugin settings on a user's account (synced across devices, via `loadData`/`saveData`)
-  or purely on the current device (never synced, via `loadLocalData`/`saveLocalData` —
-  intended for secrets or device-specific values a plugin shouldn't silently propagate,
-  e.g. a locally-held key)
+- Store private plugin data on a user's account (shared across devices) or in local storage
 
 ### Plugins CANNOT:
 

--- a/src/js/plugins/pluginLocalDataStore.js
+++ b/src/js/plugins/pluginLocalDataStore.js
@@ -1,29 +1,52 @@
 // Device-local (unsynced) storage for arbitrary plugin data — the local
-// counterpart to loadData/saveData, which round-trips through the user's
-// AT-proto preferences record and syncs across every device/session on the
-// account. Some plugin data should never leave the device it was created on
-// (e.g. a locally-held secret key a "tags"-style plugin uses to derive
-// record keys) — this is that tier. Mirrors the existing precedent in
-// pluginEndpointStore.js (device-local storage for a plugin's configured
-// network endpoint), generalized to hold arbitrary JSON rather than a
-// single URL string.
+// counterpart to loadData/saveData, which sync across devices via the
+// account's preferences. Sessions without a DID get a PluginMemoryDataStore
+// instead, which lasts only for the session.
 
-const KEY_PREFIX = "improPluginLocalData:";
+const KEY_PREFIX = "improPluginLocalData";
 
-export function getLocalData(pluginId) {
-  const raw = localStorage.getItem(KEY_PREFIX + pluginId);
-  if (raw == null) return null;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
+export class PluginLocalDataStore {
+  constructor(did) {
+    this.did = did;
+  }
+
+  _key(pluginId) {
+    return `${KEY_PREFIX}:${this.did}:${pluginId}`;
+  }
+
+  get(pluginId) {
+    const raw = localStorage.getItem(this._key(pluginId));
+    if (raw == null) return null;
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  set(pluginId, data) {
+    localStorage.setItem(this._key(pluginId), JSON.stringify(data));
+  }
+
+  clear(pluginId) {
+    localStorage.removeItem(this._key(pluginId));
   }
 }
 
-export function setLocalData(pluginId, data) {
-  localStorage.setItem(KEY_PREFIX + pluginId, JSON.stringify(data));
-}
+export class PluginMemoryDataStore {
+  constructor() {
+    this._data = new Map();
+  }
 
-export function clearLocalData(pluginId) {
-  localStorage.removeItem(KEY_PREFIX + pluginId);
+  get(pluginId) {
+    return this._data.get(pluginId) ?? null;
+  }
+
+  set(pluginId, data) {
+    this._data.set(pluginId, data);
+  }
+
+  clear(pluginId) {
+    this._data.delete(pluginId);
+  }
 }

--- a/src/js/plugins/pluginLocalDataStore.js
+++ b/src/js/plugins/pluginLocalDataStore.js
@@ -1,0 +1,29 @@
+// Device-local (unsynced) storage for arbitrary plugin data — the local
+// counterpart to loadData/saveData, which round-trips through the user's
+// AT-proto preferences record and syncs across every device/session on the
+// account. Some plugin data should never leave the device it was created on
+// (e.g. a locally-held secret key a "tags"-style plugin uses to derive
+// record keys) — this is that tier. Mirrors the existing precedent in
+// pluginEndpointStore.js (device-local storage for a plugin's configured
+// network endpoint), generalized to hold arbitrary JSON rather than a
+// single URL string.
+
+const KEY_PREFIX = "improPluginLocalData:";
+
+export function getLocalData(pluginId) {
+  const raw = localStorage.getItem(KEY_PREFIX + pluginId);
+  if (raw == null) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+export function setLocalData(pluginId, data) {
+  localStorage.setItem(KEY_PREFIX + pluginId, JSON.stringify(data));
+}
+
+export function clearLocalData(pluginId) {
+  localStorage.removeItem(KEY_PREFIX + pluginId);
+}

--- a/src/js/plugins/pluginService.js
+++ b/src/js/plugins/pluginService.js
@@ -12,6 +12,11 @@ import {
   LocalPluginRegistry,
 } from "/js/plugins/pluginRegistry.js";
 import { PluginCache } from "/js/plugins/pluginCache.js";
+import {
+  getLocalData,
+  setLocalData,
+  clearLocalData,
+} from "/js/plugins/pluginLocalDataStore.js";
 import { PluginPreferencesManager } from "/js/plugins/pluginPreferencesManager.js";
 import { SourceProvider } from "/js/plugins/sourceProvider.js";
 import { PluginStylesLoader } from "/js/plugins/pluginStylesLoader.js";
@@ -350,6 +355,14 @@ export class PluginService extends ReactiveStore {
 
     this.pluginBridge.addHostMethod("saveData", async (plugin, { data }) => {
       await this.prefManager.writeSettingsForPlugin(plugin.pluginId, data);
+    });
+
+    this.pluginBridge.addHostMethod("loadLocalData", (plugin) => {
+      return getLocalData(plugin.pluginId);
+    });
+
+    this.pluginBridge.addHostMethod("saveLocalData", (plugin, { data }) => {
+      setLocalData(plugin.pluginId, data);
     });
 
     this.pluginBridge.addHostMethod(
@@ -835,6 +848,7 @@ export class PluginService extends ReactiveStore {
     this.pluginBridge.unloadPlugin(pluginId);
     await this.prefManager.removeInstalledPlugin(pluginId);
     await this.prefManager.clearSettingsForPlugin(pluginId);
+    clearLocalData(pluginId);
     await this._reconcileCache(this.prefManager.$installedPlugins.get());
   }
 

--- a/src/js/plugins/pluginService.js
+++ b/src/js/plugins/pluginService.js
@@ -13,9 +13,8 @@ import {
 } from "/js/plugins/pluginRegistry.js";
 import { PluginCache } from "/js/plugins/pluginCache.js";
 import {
-  getLocalData,
-  setLocalData,
-  clearLocalData,
+  PluginLocalDataStore,
+  PluginMemoryDataStore,
 } from "/js/plugins/pluginLocalDataStore.js";
 import { PluginPreferencesManager } from "/js/plugins/pluginPreferencesManager.js";
 import { SourceProvider } from "/js/plugins/sourceProvider.js";
@@ -192,6 +191,9 @@ export class PluginService extends ReactiveStore {
       this.prefManager.$installedPlugins.get(),
     );
     this.session = session;
+    this.localDataStore = session?.did
+      ? new PluginLocalDataStore(session.did)
+      : new PluginMemoryDataStore();
     this.isPreviewMode = false;
     this._dataLayer = dataLayer;
     this._hiddenFeedItemsStore = hiddenFeedItemsStore;
@@ -358,11 +360,11 @@ export class PluginService extends ReactiveStore {
     });
 
     this.pluginBridge.addHostMethod("loadLocalData", (plugin) => {
-      return getLocalData(plugin.pluginId);
+      return this.localDataStore.get(plugin.pluginId);
     });
 
     this.pluginBridge.addHostMethod("saveLocalData", (plugin, { data }) => {
-      setLocalData(plugin.pluginId, data);
+      this.localDataStore.set(plugin.pluginId, data);
     });
 
     this.pluginBridge.addHostMethod(
@@ -848,7 +850,7 @@ export class PluginService extends ReactiveStore {
     this.pluginBridge.unloadPlugin(pluginId);
     await this.prefManager.removeInstalledPlugin(pluginId);
     await this.prefManager.clearSettingsForPlugin(pluginId);
-    clearLocalData(pluginId);
+    this.localDataStore.clear(pluginId);
     await this._reconcileCache(this.prefManager.$installedPlugins.get());
   }
 

--- a/tests/unit/specs/plugins/pluginLocalDataStore.test.js
+++ b/tests/unit/specs/plugins/pluginLocalDataStore.test.js
@@ -1,53 +1,108 @@
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import {
-  getLocalData,
-  setLocalData,
-  clearLocalData,
+  PluginLocalDataStore,
+  PluginMemoryDataStore,
 } from "/js/plugins/pluginLocalDataStore.js";
 
-describe("pluginLocalDataStore", () => {
+const DID_ONE = "did:plc:user-one";
+const DID_TWO = "did:plc:user-two";
+
+describe("PluginLocalDataStore", () => {
   beforeEach(() => {
     localStorage.clear();
   });
 
   it("returns null when nothing has been stored", () => {
-    assert.deepEqual(getLocalData("a"), null);
+    const store = new PluginLocalDataStore(DID_ONE);
+    assert.deepEqual(store.get("a"), null);
   });
 
   it("round-trips arbitrary JSON data", () => {
+    const store = new PluginLocalDataStore(DID_ONE);
     const data = { keys: [{ id: "k1", label: "personal", secret: "shh" }] };
-    setLocalData("a", data);
-    assert.deepEqual(getLocalData("a"), data);
+    store.set("a", data);
+    assert.deepEqual(store.get("a"), data);
   });
 
   it("isolates data between plugin ids", () => {
-    setLocalData("a", { value: 1 });
-    setLocalData("b", { value: 2 });
-    assert.deepEqual(getLocalData("a"), { value: 1 });
-    assert.deepEqual(getLocalData("b"), { value: 2 });
+    const store = new PluginLocalDataStore(DID_ONE);
+    store.set("a", { value: 1 });
+    store.set("b", { value: 2 });
+    assert.deepEqual(store.get("a"), { value: 1 });
+    assert.deepEqual(store.get("b"), { value: 2 });
   });
 
-  it("clearLocalData removes only that plugin's entry", () => {
-    setLocalData("a", { value: 1 });
-    setLocalData("b", { value: 2 });
-    clearLocalData("a");
-    assert.deepEqual(getLocalData("a"), null);
-    assert.deepEqual(getLocalData("b"), { value: 2 });
+  it("isolates data between account dids", () => {
+    const storeOne = new PluginLocalDataStore(DID_ONE);
+    const storeTwo = new PluginLocalDataStore(DID_TWO);
+    storeOne.set("a", { secret: "one" });
+    assert.deepEqual(storeTwo.get("a"), null);
+    storeTwo.set("a", { secret: "two" });
+    assert.deepEqual(storeOne.get("a"), { secret: "one" });
+    assert.deepEqual(storeTwo.get("a"), { secret: "two" });
+  });
+
+  it("clear removes only that plugin's entry for that account", () => {
+    const storeOne = new PluginLocalDataStore(DID_ONE);
+    const storeTwo = new PluginLocalDataStore(DID_TWO);
+    storeOne.set("a", { value: 1 });
+    storeOne.set("b", { value: 2 });
+    storeTwo.set("a", { value: 3 });
+    storeOne.clear("a");
+    assert.deepEqual(storeOne.get("a"), null);
+    assert.deepEqual(storeOne.get("b"), { value: 2 });
+    assert.deepEqual(storeTwo.get("a"), { value: 3 });
   });
 
   it("overwrites previously stored data", () => {
-    setLocalData("a", { value: 1 });
-    setLocalData("a", { value: 2 });
-    assert.deepEqual(getLocalData("a"), { value: 2 });
+    const store = new PluginLocalDataStore(DID_ONE);
+    store.set("a", { value: 1 });
+    store.set("a", { value: 2 });
+    assert.deepEqual(store.get("a"), { value: 2 });
   });
 
   it("returns null instead of throwing on corrupted stored data", () => {
-    localStorage.setItem("improPluginLocalData:a", "{not json");
-    assert.deepEqual(getLocalData("a"), null);
+    const store = new PluginLocalDataStore(DID_ONE);
+    localStorage.setItem(`improPluginLocalData:${DID_ONE}:a`, "{not json");
+    assert.deepEqual(store.get("a"), null);
   });
 
-  it("clearLocalData is a no-op when nothing was stored", () => {
-    assert.doesNotThrow(() => clearLocalData("never-stored"));
+  it("clear is a no-op when nothing was stored", () => {
+    const store = new PluginLocalDataStore(DID_ONE);
+    assert.doesNotThrow(() => store.clear("never-stored"));
+  });
+});
+
+describe("PluginMemoryDataStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("round-trips data without touching localStorage", () => {
+    const store = new PluginMemoryDataStore();
+    store.set("a", { value: "anon" });
+    assert.deepEqual(store.get("a"), { value: "anon" });
+    assert.deepEqual(localStorage.length, 0);
+  });
+
+  it("returns null when nothing has been stored", () => {
+    const store = new PluginMemoryDataStore();
+    assert.deepEqual(store.get("a"), null);
+  });
+
+  it("isolates data between store instances", () => {
+    const storeOne = new PluginMemoryDataStore();
+    storeOne.set("a", { value: 1 });
+    assert.deepEqual(new PluginMemoryDataStore().get("a"), null);
+  });
+
+  it("clear removes only that plugin's entry", () => {
+    const store = new PluginMemoryDataStore();
+    store.set("a", { value: 1 });
+    store.set("b", { value: 2 });
+    store.clear("a");
+    assert.deepEqual(store.get("a"), null);
+    assert.deepEqual(store.get("b"), { value: 2 });
   });
 });

--- a/tests/unit/specs/plugins/pluginLocalDataStore.test.js
+++ b/tests/unit/specs/plugins/pluginLocalDataStore.test.js
@@ -1,0 +1,53 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  getLocalData,
+  setLocalData,
+  clearLocalData,
+} from "/js/plugins/pluginLocalDataStore.js";
+
+describe("pluginLocalDataStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns null when nothing has been stored", () => {
+    assert.deepEqual(getLocalData("a"), null);
+  });
+
+  it("round-trips arbitrary JSON data", () => {
+    const data = { keys: [{ id: "k1", label: "personal", secret: "shh" }] };
+    setLocalData("a", data);
+    assert.deepEqual(getLocalData("a"), data);
+  });
+
+  it("isolates data between plugin ids", () => {
+    setLocalData("a", { value: 1 });
+    setLocalData("b", { value: 2 });
+    assert.deepEqual(getLocalData("a"), { value: 1 });
+    assert.deepEqual(getLocalData("b"), { value: 2 });
+  });
+
+  it("clearLocalData removes only that plugin's entry", () => {
+    setLocalData("a", { value: 1 });
+    setLocalData("b", { value: 2 });
+    clearLocalData("a");
+    assert.deepEqual(getLocalData("a"), null);
+    assert.deepEqual(getLocalData("b"), { value: 2 });
+  });
+
+  it("overwrites previously stored data", () => {
+    setLocalData("a", { value: 1 });
+    setLocalData("a", { value: 2 });
+    assert.deepEqual(getLocalData("a"), { value: 2 });
+  });
+
+  it("returns null instead of throwing on corrupted stored data", () => {
+    localStorage.setItem("improPluginLocalData:a", "{not json");
+    assert.deepEqual(getLocalData("a"), null);
+  });
+
+  it("clearLocalData is a no-op when nothing was stored", () => {
+    assert.doesNotThrow(() => clearLocalData("never-stored"));
+  });
+});

--- a/tests/unit/specs/plugins/pluginService.test.js
+++ b/tests/unit/specs/plugins/pluginService.test.js
@@ -7,10 +7,6 @@ import {
 import { Signal, SignalMap } from "/js/signals.js";
 import { EventEmitter } from "/js/eventEmitter.js";
 import { HiddenFeedItemsStore } from "/js/dataLayer/hiddenFeedItemsStore.js";
-import {
-  getLocalData,
-  setLocalData,
-} from "/js/plugins/pluginLocalDataStore.js";
 import { respondToConfirm } from "../../testHelpers.js";
 
 function emptyDataLayer() {
@@ -624,10 +620,10 @@ describe("uninstallPlugin", () => {
     state.installedPlugins = [
       { id: "a", version: "1.0.0", repo: "ow/a", enabled: true },
     ];
-    setLocalData("a", { keys: [{ id: "k1", secret: "shh" }] });
-    assert.notDeepEqual(getLocalData("a"), null);
+    service.localDataStore.set("a", { keys: [{ id: "k1", secret: "shh" }] });
+    assert.notDeepEqual(service.localDataStore.get("a"), null);
     await service.uninstallPlugin("a");
-    assert.deepEqual(getLocalData("a"), null);
+    assert.deepEqual(service.localDataStore.get("a"), null);
   });
 });
 

--- a/tests/unit/specs/plugins/pluginService.test.js
+++ b/tests/unit/specs/plugins/pluginService.test.js
@@ -7,6 +7,10 @@ import {
 import { Signal, SignalMap } from "/js/signals.js";
 import { EventEmitter } from "/js/eventEmitter.js";
 import { HiddenFeedItemsStore } from "/js/dataLayer/hiddenFeedItemsStore.js";
+import {
+  getLocalData,
+  setLocalData,
+} from "/js/plugins/pluginLocalDataStore.js";
 import { respondToConfirm } from "../../testHelpers.js";
 
 function emptyDataLayer() {
@@ -613,6 +617,17 @@ describe("uninstallPlugin", () => {
     // Cache should be reconciled against the remaining plugin only
     assert.deepEqual(reconcileCalls.length, 1);
     assert.deepEqual(reconcileCalls[0], ["https://cache.test/b/1.0.0/ow/b"]);
+  });
+
+  it("also clears device-local plugin data", async () => {
+    const { service, state } = makeService();
+    state.installedPlugins = [
+      { id: "a", version: "1.0.0", repo: "ow/a", enabled: true },
+    ];
+    setLocalData("a", { keys: [{ id: "k1", secret: "shh" }] });
+    assert.notDeepEqual(getLocalData("a"), null);
+    await service.uninstallPlugin("a");
+    assert.deepEqual(getLocalData("a"), null);
   });
 });
 
@@ -1936,6 +1951,50 @@ describe("getRecord host method", () => {
       );
     }
     assert.deepEqual(fetched, false);
+  });
+});
+
+describe("loadLocalData/saveLocalData host methods", () => {
+  function makeServiceWithRealBridge() {
+    const { provider } = makeProvider();
+    return new PluginService(
+      provider,
+      null,
+      emptyDataLayer(),
+      new HiddenFeedItemsStore(),
+    );
+  }
+
+  function getHandler(service, name) {
+    return service.pluginBridge._hostCallHandlers.get(name);
+  }
+
+  const plugin = { pluginId: "tags", permissions: {} };
+
+  it("returns null before anything has been saved", () => {
+    const service = makeServiceWithRealBridge();
+    assert.deepEqual(getHandler(service, "loadLocalData")(plugin), null);
+  });
+
+  it("round-trips data through saveLocalData/loadLocalData", () => {
+    const service = makeServiceWithRealBridge();
+    const data = { keys: [{ id: "k1", label: "personal", secret: "shh" }] };
+    getHandler(service, "saveLocalData")(plugin, { data });
+    assert.deepEqual(getHandler(service, "loadLocalData")(plugin), data);
+  });
+
+  it("isolates data between plugins", () => {
+    const service = makeServiceWithRealBridge();
+    getHandler(service, "saveLocalData")(plugin, { data: { a: 1 } });
+    getHandler(service, "saveLocalData")(
+      { pluginId: "other", permissions: {} },
+      { data: { a: 2 } },
+    );
+    assert.deepEqual(getHandler(service, "loadLocalData")(plugin), { a: 1 });
+    assert.deepEqual(
+      getHandler(service, "loadLocalData")({ pluginId: "other" }),
+      { a: 2 },
+    );
   });
 });
 


### PR DESCRIPTION
Split out of the earlier combined PR, per feedback — this is just the
device-local storage piece.

## Summary
- `loadData`/`saveData` round-trip through the account's synced AT-proto
  preferences record. Some plugin data (e.g. a locally-held secret key)
  shouldn't silently propagate across devices — `loadLocalData`/`saveLocalData`
  add that tier, `localStorage`-backed and scoped per plugin, mirroring the
  existing `pluginEndpointStore.js` precedent but generalized to arbitrary
  JSON.
- Cleared on uninstall alongside the existing synced-settings cleanup.

## Test plan
- [x] `npm run test:unit` passes (new `pluginLocalDataStore.test.js` +
      `loadLocalData/saveLocalData host methods` in `pluginService.test.js`)