### PR TITLE
Fix plugin components losing plugin-component-context inside plugin modals

### DIFF
--- a/src/js/context-provider.js
+++ b/src/js/context-provider.js
@@ -1,9 +1,29 @@
+// Content mounted outside a <context-provider>'s subtree can't reach it via
+// closest() — e.g. plugin modals (pluginModal.js) mount their <dialog>
+// directly on <body>, as a sibling of the main layout, rather than nested
+// inside it. Track the most recently connected provider per context-id as a
+// fallback for exactly that case, so such content can still resolve context
+// instead of throwing.
+const fallbackProviders = new Map();
+
 class ContextProvider extends HTMLElement {
   set context(value) {
     this._context = value;
   }
   get context() {
     return this._context;
+  }
+
+  connectedCallback() {
+    const contextId = this.getAttribute("context-id");
+    if (contextId) fallbackProviders.set(contextId, this);
+  }
+
+  disconnectedCallback() {
+    const contextId = this.getAttribute("context-id");
+    if (contextId && fallbackProviders.get(contextId) === this) {
+      fallbackProviders.delete(contextId);
+    }
   }
 }
 customElements.define("context-provider", ContextProvider);
@@ -12,7 +32,9 @@ export function getContext(node, contextId) {
   const selector = contextId
     ? `context-provider[context-id="${contextId}"]`
     : "context-provider";
-  const provider = node.closest(selector);
+  const provider =
+    node.closest(selector) ??
+    (contextId ? fallbackProviders.get(contextId) : null);
   if (!provider) {
     throw new Error(
       contextId

--- a/tests/unit/specs/context-provider.test.js
+++ b/tests/unit/specs/context-provider.test.js
@@ -1,0 +1,92 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { getContext } from "/js/context-provider.js";
+
+function clearDOM() {
+  document.body.innerHTML = "";
+}
+
+describe("getContext", () => {
+  beforeEach(() => {
+    clearDOM();
+  });
+
+  it("resolves context from an ancestor <context-provider>", () => {
+    const provider = document.createElement("context-provider");
+    provider.setAttribute("context-id", "test-context");
+    provider.context = { value: "from-ancestor" };
+    const child = document.createElement("div");
+    provider.appendChild(child);
+    document.body.appendChild(provider);
+
+    assert.deepEqual(getContext(child, "test-context"), {
+      value: "from-ancestor",
+    });
+  });
+
+  it("throws when no provider exists anywhere", () => {
+    const orphan = document.createElement("div");
+    document.body.appendChild(orphan);
+    assert.throws(
+      () => getContext(orphan, "test-context"),
+      /no <context-provider context-id="test-context"> ancestor/,
+    );
+  });
+
+  // Regression: content mounted outside a provider's subtree (e.g. a plugin
+  // modal's <dialog>, appended straight to <body> as a sibling of the main
+  // layout's <context-provider>, per pluginModal.js) previously had no way
+  // to resolve context at all, even though a provider for that id was live
+  // elsewhere in the document.
+  it("falls back to a provider connected elsewhere in the document when the node has no ancestor provider", () => {
+    const provider = document.createElement("context-provider");
+    provider.setAttribute("context-id", "test-context");
+    provider.context = { value: "from-fallback" };
+    document.body.appendChild(provider);
+
+    const sibling = document.createElement("div");
+    document.body.appendChild(sibling);
+
+    assert.equal(
+      sibling.closest('context-provider[context-id="test-context"]'),
+      null,
+    );
+    assert.deepEqual(getContext(sibling, "test-context"), {
+      value: "from-fallback",
+    });
+  });
+
+  it("prefers an ancestor provider over an unrelated fallback provider", () => {
+    const staleProvider = document.createElement("context-provider");
+    staleProvider.setAttribute("context-id", "test-context");
+    staleProvider.context = { value: "stale" };
+    document.body.appendChild(staleProvider);
+
+    const ownProvider = document.createElement("context-provider");
+    ownProvider.setAttribute("context-id", "test-context");
+    ownProvider.context = { value: "own-ancestor" };
+    const child = document.createElement("div");
+    ownProvider.appendChild(child);
+    document.body.appendChild(ownProvider);
+
+    assert.deepEqual(getContext(child, "test-context"), {
+      value: "own-ancestor",
+    });
+  });
+
+  it("stops falling back once the provider disconnects", () => {
+    const provider = document.createElement("context-provider");
+    provider.setAttribute("context-id", "test-context");
+    provider.context = { value: "from-fallback" };
+    document.body.appendChild(provider);
+
+    const orphan = document.createElement("div");
+    document.body.appendChild(orphan);
+    assert.deepEqual(getContext(orphan, "test-context"), {
+      value: "from-fallback",
+    });
+
+    provider.remove();
+    assert.throws(() => getContext(orphan, "test-context"));
+  });
+});

--- a/tests/unit/specs/plugins/pluginModal.test.js
+++ b/tests/unit/specs/plugins/pluginModal.test.js
@@ -213,6 +213,56 @@ describe("showPluginModal", () => {
     hidePluginModal({ pluginId: "iso.plugin", modalId: modalIdA });
     hidePluginModal({ pluginId: "iso.plugin", modalId: modalIdB });
   });
+
+  // Regression: plugin modals mount their <dialog> straight onto <body> (see
+  // above), outside the main layout's <context-provider>. A plugin component
+  // rendered inside modal content — e.g. profile-moderation-tools' relationship
+  // modal using <plugin-profiles-list> — calls getContext() for
+  // "plugin-component-context" from its connectedCallback. Before the
+  // context-provider.js fallback fix, that threw as soon as the element was
+  // inserted (jsdom swallows the throw from an appendChild-triggered
+  // connectedCallback, so the modal just rendered visible-but-empty rather
+  // than surfacing an error — exactly what was reported), since closest()
+  // never finds a provider outside the dialog's own subtree.
+  it("lets a real plugin-profiles-list inside the modal resolve plugin-component-context via a provider mounted elsewhere in the document", () => {
+    clearDOM();
+
+    // Stand-in for mainLayout.js's <context-provider>, mounted in the app
+    // root rather than as an ancestor of the modal's dialog.
+    const layoutProvider = document.createElement("context-provider");
+    layoutProvider.setAttribute("context-id", "plugin-component-context");
+    const componentContext = {
+      dataLayer: {
+        declarative: { ensureDetailedProfiles: async () => [] },
+        derived: { $hydratedProfiles: { get: () => undefined } },
+      },
+    };
+    layoutProvider.context = componentContext;
+    document.body.appendChild(layoutProvider);
+
+    showPluginModal({
+      pluginId: "probe.plugin",
+      modalId: uniqueModalId("probe"),
+      title: { tag: "span", text: "T" },
+      // Mirrors the real relationship modal: a wrapper div whose children
+      // include the profiles list, not the list as the bare top-level node.
+      content: {
+        tag: "div",
+        children: [{ tag: "plugin-profiles-list", attrs: { dids: "" } }],
+      },
+    });
+
+    const list = document.querySelector("plugin-profiles-list");
+    assert(list !== null);
+    assert.equal(
+      list.closest('context-provider[context-id="plugin-component-context"]'),
+      null,
+      "sanity check: the list has no ancestor provider, so this must go through the fallback",
+    );
+    // dataLayer is only assigned once getContext() resolves successfully —
+    // it stays undefined if getContext() threw during connectedCallback.
+    assert.equal(list.dataLayer, componentContext.dataLayer);
+  });
 });
 
 describe("hidePluginModal", () => {


### PR DESCRIPTION
## Summary

`getContext(node, "plugin-component-context")` in `context-provider.js` resolves purely via `node.closest(...)`. Since `ab7be4f` ("Refactor plugin service"), that's the only way plugin components (`<plugin-profiles-list>`, `<plugin-posts-feed>`) reach `dataLayer`/`pluginService`/etc. — it replaced the previous approach of injecting those as plain properties on the element at creation time, which worked regardless of DOM position.

Plugin modals (`pluginModal.js`) mount their `<dialog>` directly on `<body>`, as a sibling of the main layout rather than a descendant of its `<context-provider>` — by design, so native `<dialog>` top-layer rendering isn't affected by the layout's stacking context. Since `ab7be4f`, any plugin component rendered inside a plugin modal has been unable to resolve `plugin-component-context`, throwing during `connectedCallback`. The symptom is quiet: the modal opens normally, but any content that depends on context just never populates.

This was first surfaced by `profile-moderation-tools`' relationship modal (`createProfilesList()` → `<plugin-profiles-list>` inside a `Modal`), but it's a host-side gap affecting any plugin that renders these components inside a modal, not anything specific to that plugin.

## Fix

Confined to `context-provider.js`. `<context-provider>` now tracks itself in a small `Map` keyed by `context-id` on `connectedCallback`/`disconnectedCallback`. `getContext()` still tries `closest()` first, and only falls back to the tracked provider when there's no DOM ancestor — which is exactly the plugin-modal case, since there's a single live `plugin-component-context` provider (the main layout's) for the app's lifetime.

No changes to `pluginModal.js`, `pluginService.js`, or `mainLayout.js` — the existing provider mainLayout already creates is reused as-is.

## Tests

- `tests/unit/specs/context-provider.test.js` (new): direct coverage of the fallback — ancestor lookup still wins when present, fallback clears on disconnect, throws when neither exists.
- `tests/unit/specs/plugins/pluginModal.test.js`: added a reproduction using the real `<plugin-profiles-list>` element inside modal content (matching the relationship-modal shape), asserting it resolves `dataLayer` from a provider that is *not* an ancestor. Verified this test fails without the fix (`dataLayer` stays `undefined`, i.e. `getContext` threw and the rest of `connectedCallback` never ran) and passes with it.

Full suite: 3711/3711 passing.

## Test plan

- [x] `npm run test:unit` — all passing
- [x] Confirmed the new `pluginModal.test.js` case fails on `main` (pre-fix) and passes with the fix