### PR TITLE
Align the author-badges plugin slot with label badges

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1870,8 +1870,24 @@ container-link {
   object-fit: cover;
 }
 
+.author-badges {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.author-badges .label-badges,
+.author-badges plugin-slot {
+  display: contents;
+}
+
+.author-badges:not(:has(.label-badge, plugin-slot:not(:empty))) {
+  display: none;
+}
+
 .large-post .label-badge {
   font-size: 13px;
+  min-height: 23px;
   padding: 3px 8px 4px;
   margin-right: 4px;
   margin-top: 5px;
@@ -1890,17 +1906,9 @@ container-link {
 }
 
 .large-post .author-badges {
-  display: flex;
-  flex-direction: column;
   gap: 4px;
   margin-top: 3px;
   margin-bottom: 4px;
-}
-
-.large-post .label-badges {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
 }
 
 .small-post .pinned-label {
@@ -3911,21 +3919,13 @@ image-carousel {
 }
 
 .chat-info-panel .author-badges {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-}
-
-.chat-info-panel .label-badges {
-  display: flex;
-  flex-wrap: wrap;
   justify-content: center;
   gap: 4px;
 }
 
 .chat-info-panel .label-badge {
   font-size: 13px;
+  min-height: 23px;
   padding: 3px 8px 4px;
   background: light-dark(var(--lightest-gray), var(--gray));
 }
@@ -5260,21 +5260,14 @@ emoji-picker-dialog emoji-picker,
 }
 
 .profile-card .author-badges {
-  display: flex;
-  flex-direction: column;
   gap: 4px;
   margin-top: 12px;
   padding: 0 16px;
 }
 
-.profile-card .label-badges {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-}
-
 .profile-card .label-badge {
   font-size: 13px;
+  min-height: 23px;
   padding: 3px 8px 4px;
   background: light-dark(var(--lightest-gray), var(--gray));
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1889,9 +1889,17 @@ container-link {
   height: 16px;
 }
 
-.large-post .label-badges {
+.large-post .author-badges {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
   margin-top: 3px;
   margin-bottom: 4px;
+}
+
+.large-post .label-badges {
+  display: contents;
 }
 
 .small-post .pinned-label {
@@ -3901,11 +3909,15 @@ image-carousel {
   text-decoration: none;
 }
 
-.chat-info-panel .label-badges {
+.chat-info-panel .author-badges {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
   gap: 4px;
+}
+
+.chat-info-panel .label-badges {
+  display: contents;
 }
 
 .chat-info-panel .label-badge {
@@ -5243,12 +5255,17 @@ emoji-picker-dialog emoji-picker,
   margin-bottom: 8px;
 }
 
-.profile-card .label-badges {
+.profile-card .author-badges {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 4px;
   margin-top: 12px;
   padding: 0 16px;
+}
+
+.profile-card .label-badges {
+  display: contents;
 }
 
 .profile-card .label-badge {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1891,15 +1891,16 @@ container-link {
 
 .large-post .author-badges {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
+  flex-direction: column;
   gap: 4px;
   margin-top: 3px;
   margin-bottom: 4px;
 }
 
 .large-post .label-badges {
-  display: contents;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
 }
 
 .small-post .pinned-label {
@@ -3911,13 +3912,16 @@ image-carousel {
 
 .chat-info-panel .author-badges {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
   gap: 4px;
 }
 
 .chat-info-panel .label-badges {
-  display: contents;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 4px;
 }
 
 .chat-info-panel .label-badge {
@@ -5257,15 +5261,16 @@ emoji-picker-dialog emoji-picker,
 
 .profile-card .author-badges {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
+  flex-direction: column;
   gap: 4px;
   margin-top: 12px;
   padding: 0 16px;
 }
 
 .profile-card .label-badges {
-  display: contents;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
 }
 
 .profile-card .label-badge {

--- a/src/js/components/plugin-slot.js
+++ b/src/js/components/plugin-slot.js
@@ -9,13 +9,14 @@ function kebabToCamel(name) {
 
 class PluginSlot extends Component {
   connectedCallback() {
-    if (this.initialized) return;
-    this.initialized = true;
-    if (!this.pluginService) {
-      throw new Error("pluginService is required");
+    if (!this.initialized) {
+      this.initialized = true;
+      if (!this.pluginService) {
+        throw new Error("pluginService is required");
+      }
+      this._pluginRoots = new Map();
+      this._currentRequest = null;
     }
-    this._pluginRoots = new Map();
-    this._currentRequest = null;
     this._subscribe();
   }
 

--- a/src/js/templates/labelBadges.template.js
+++ b/src/js/templates/labelBadges.template.js
@@ -2,15 +2,22 @@ import { html } from "/js/lib/lit-html.js";
 import { getLabelNameAndDescription } from "/js/dataHelpers.js";
 import "/js/components/plugin-slot.js";
 
+// Wraps the label badges and the plugin author-badges slot in one shared
+// container so a plugin's badge lines up with moderation labels wherever
+// both can appear, instead of the plugin-slot sitting outside whatever
+// padding/alignment a given context applies to .label-badges alone.
 export function authorBadgesTemplate({ badgeLabels, did, pluginService }) {
-  return html`${badgeLabels?.length ? labelBadgesTemplate({ badgeLabels }) : ""}
-  ${pluginService
-    ? html`<plugin-slot
-        name="author-badges"
-        context-did=${did ?? ""}
-        .pluginService=${pluginService}
-      ></plugin-slot>`
-    : ""}`;
+  if (!badgeLabels?.length && !pluginService) return "";
+  return html`<div class="author-badges">
+    ${badgeLabels?.length ? labelBadgesTemplate({ badgeLabels }) : ""}
+    ${pluginService
+      ? html`<plugin-slot
+          name="author-badges"
+          context-did=${did ?? ""}
+          .pluginService=${pluginService}
+        ></plugin-slot>`
+      : ""}
+  </div>`;
 }
 
 function labelBadgesTemplate({ badgeLabels }) {

--- a/src/js/templates/labelBadges.template.js
+++ b/src/js/templates/labelBadges.template.js
@@ -2,12 +2,7 @@ import { html } from "/js/lib/lit-html.js";
 import { getLabelNameAndDescription } from "/js/dataHelpers.js";
 import "/js/components/plugin-slot.js";
 
-// Wraps the label badges and the plugin author-badges slot in one shared
-// container so a plugin's badge lines up with moderation labels wherever
-// both can appear, instead of the plugin-slot sitting outside whatever
-// padding/alignment a given context applies to .label-badges alone.
 export function authorBadgesTemplate({ badgeLabels, did, pluginService }) {
-  if (!badgeLabels?.length && !pluginService) return "";
   return html`<div class="author-badges">
     ${badgeLabels?.length ? labelBadgesTemplate({ badgeLabels }) : ""}
     ${pluginService

--- a/tests/unit/specs/components/plugin-slot.test.js
+++ b/tests/unit/specs/components/plugin-slot.test.js
@@ -426,5 +426,59 @@ describe("plugin-slot", () => {
       await flushMicrotasks();
       assert.deepEqual(invoked, false);
     });
+
+    it("re-subscribes and re-renders when reconnected after a disconnect", async () => {
+      const pluginService = makePluginService({
+        entries: {
+          x: [
+            {
+              pluginId: "alpha",
+              invoke: async () => ({ tag: "div", text: "A" }),
+            },
+          ],
+        },
+      });
+      const slot = makeSlot({ pluginService, name: "x" });
+      document.body.appendChild(slot);
+      await flushMicrotasks();
+      assert.deepEqual(slot.children.length, 1);
+
+      slot.remove();
+      document.body.appendChild(slot);
+      await flushMicrotasks();
+      assert.deepEqual(slot.children.length, 1);
+      assert.deepEqual(slot.children[0].textContent, "A");
+
+      // The reconnected subscription must also react to later registrations.
+      pluginService.setSlotEntries("x", [
+        { pluginId: "alpha", invoke: async () => ({ tag: "div", text: "A2" }) },
+        { pluginId: "beta", invoke: async () => ({ tag: "div", text: "B" }) },
+      ]);
+      await flushMicrotasks();
+      assert.deepEqual(slot.children.length, 2);
+    });
+
+    it("renders when reparented synchronously before the first invoke resolves", async () => {
+      // Mimics infinite-scroll-container, which moves its children into an
+      // inner wrapper during its own connectedCallback.
+      const pluginService = makePluginService({
+        entries: {
+          x: [
+            {
+              pluginId: "alpha",
+              invoke: async () => ({ tag: "div", text: "A" }),
+            },
+          ],
+        },
+      });
+      const slot = makeSlot({ pluginService, name: "x" });
+      document.body.appendChild(slot);
+      const wrapper = document.createElement("div");
+      document.body.appendChild(wrapper);
+      wrapper.appendChild(slot);
+      await flushMicrotasks();
+      assert.deepEqual(slot.children.length, 1);
+      assert.deepEqual(slot.children[0].textContent, "A");
+    });
   });
 });


### PR DESCRIPTION
## Summary

`authorBadgesTemplate` (added in #24 and refactored to its current shape
shortly after) renders `<plugin-slot name="author-badges">` as a sibling
of the `.label-badges` div rather than inside a shared container. That's
invisible as long as the slot renders nothing (`plugin-slot:empty` is
`display: none`), but three contexts style `.label-badges` directly for
layout:

- `.profile-card .label-badges` — `padding: 0 16px`
- `.large-post .label-badges` — margin
- `.chat-info-panel .label-badges` — centered flex row

so a plugin that actually renders content into the slot sits outside all
of that — flush against the edge instead of aligned with any label badges
next to it. Most visible on profile pages, where the horizontal padding
is the largest of the three. Surfaced by a community plugin author testing
a real badge-rendering plugin against this slot.

## Fix

Wraps both the label badges and the plugin slot in a shared
`.author-badges` container, moves each context's layout rules onto that
wrapper, and sets `.label-badges` to `display: contents` in those same
three scopes so the label pills flow into the same row as the plugin's
content instead of being boxed separately from it.

`small-post`/`quoted-post`/`profile-list-item` weren't touched — they
never had a competing `.label-badges` layout rule, so nothing was
misaligning there.

## Test plan

- [x] Full unit suite passes (3773/3773), including
      `authorBadges`/`profileCard`/`largePost`/`smallPost`/`postEmbed`/`chatDetail`
      template and view suites specifically
- [x] Production build succeeds; confirmed `.author-badges` rules land in
      the built stylesheet
- [x] Confirmed no other JS references `.label-badges` for DOM traversal
      (only the template that defines it), so the added wrapper element
      is safe