### PR TITLE
Add real system notifications (open-tab + cross-device push)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 node_modules
 build
 .env
+# Per-deployment Cloudflare Pages config (KV namespace IDs, vars) - not
+# shared across forks/deployments, generate your own via `wrangler pages
+# project create` + `wrangler kv namespace create`.
+wrangler.toml
+wrangler.jsonc
+playwright.remote.config.js
 .context
 tests/e2e/.results
 tests/.artifacts/visual

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ If you notice a bug or feature missing, please open [an issue](https://github.co
 
 Impro uses the [Bluesky API](https://docs.bsky.app/docs/category/http-reference) for authentication and data fetching. Additionally, it uses [Constellation](https://constellation.microcosm.blue/) to populate blocked replies.
 
+Optionally, a deployment can enable cross-device push notifications by configuring a Cloudflare KV binding (`PUSH_SUBSCRIPTIONS`) and VAPID keys (`VAPID_PRIVATE_JWK`, `VAPID_PUBLIC_KEY`, `VAPID_SUBJECT`) — see `scripts/generate-vapid-keypair.js`. Without this configured, notifications still work locally on whichever device has Impro open.
+
 ## Dependencies
 
 Impro uses the following libraries:

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -34,6 +34,9 @@ export default async function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("src/_headers");
   eleventyConfig.addPassthroughCopy("src/_routes.json");
   eleventyConfig.addPassthroughCopy("src/plugin-sandbox.html");
+  // Served at site root (not under /js/) so it gets a stable, unhashed URL
+  // and default max scope; must bypass the src/js/**/*.js cache-busting pass.
+  eleventyConfig.addPassthroughCopy("src/sw.js");
 
   // Prevent sandbox from being treated as a template
   eleventyConfig.ignores.add("src/plugin-sandbox.html");

--- a/functions/_lib/dpopVerify.js
+++ b/functions/_lib/dpopVerify.js
@@ -1,0 +1,88 @@
+// Shared helpers for functions/oauth/assertion.js and functions/push/*.js.
+// Files under functions/_lib/ are not routed by Cloudflare Pages (any path
+// segment starting with "_" is excluded from routing), so this is safe to
+// import from sibling function files without creating an extra endpoint.
+
+export function base64UrlEncode(buffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+export function encodeUtf8(str) {
+  return new TextEncoder().encode(str);
+}
+
+const GET_SESSION_PATH = "/xrpc/com.atproto.server.getSession";
+
+export class IdentityVerificationError extends Error {
+  constructor(code) {
+    super(code);
+    this.name = "IdentityVerificationError";
+    this.code = code;
+  }
+}
+
+// Confirms "this caller is currently authenticated as some DID" without
+// this function ever holding a usable credential of its own. The browser's
+// OAuth session is DPoP-bound to a non-extractable, browser-generated key
+// (see src/js/oauth.js), so a bare access token is useless off-browser --
+// but a DPoP proof the browser already signed for one specific request is
+// safe to forward. We proxy exactly that one request (a GET to the caller's
+// own PDS's com.atproto.server.getSession) and trust the PDS's own
+// authoritative response.
+//
+// `verificationUrl` must be the exact URL the browser used as the DPoP
+// proof's `htu` claim (https, path ending in GET_SESSION_PATH) -- proxying
+// only that shape keeps this from being usable as an open HTTP proxy.
+export async function verifyIdentity({
+  verificationUrl,
+  accessToken,
+  dpopProof,
+}) {
+  if (!verificationUrl || !accessToken || !dpopProof) {
+    throw new IdentityVerificationError("missing_credentials");
+  }
+  let url;
+  try {
+    url = new URL(verificationUrl);
+  } catch {
+    throw new IdentityVerificationError("invalid_verification_url");
+  }
+  if (url.protocol !== "https:" || !url.pathname.endsWith(GET_SESSION_PATH)) {
+    throw new IdentityVerificationError("invalid_verification_url");
+  }
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `DPoP ${accessToken}`,
+      DPoP: dpopProof,
+    },
+  });
+
+  if (response.status === 400 || response.status === 401) {
+    let body = null;
+    try {
+      body = await response.json();
+    } catch {
+      // ignore
+    }
+    const nonce = response.headers.get("DPoP-Nonce");
+    if (body?.error === "use_dpop_nonce" && nonce) {
+      return { needsNonce: true, nonce };
+    }
+    throw new IdentityVerificationError("unauthorized");
+  }
+  if (!response.ok) {
+    throw new IdentityVerificationError("pds_error");
+  }
+
+  const data = await response.json();
+  if (!data?.did) {
+    throw new IdentityVerificationError("missing_did");
+  }
+  return { did: data.did };
+}

--- a/functions/_lib/kvKeys.js
+++ b/functions/_lib/kvKeys.js
@@ -1,0 +1,24 @@
+// KV key format for PUSH_SUBSCRIPTIONS, shared so subscribe/unsubscribe/relay
+// can't drift out of sync with each other.
+
+async function sha256Hex(value) {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function subscriptionKey(did, endpoint) {
+  return `sub:${did}:${await sha256Hex(endpoint)}`;
+}
+
+export function subscriptionPrefix(did) {
+  return `sub:${did}:`;
+}
+
+export function throttleKey(action, did) {
+  return `throttle:${action}:${did}`;
+}

--- a/functions/_lib/vapid.js
+++ b/functions/_lib/vapid.js
@@ -1,0 +1,46 @@
+import { base64UrlEncode, encodeUtf8 } from "./dpopVerify.js";
+
+// RFC 8292 recommends VAPID JWTs expire within 24h; keep well under that.
+const VAPID_JWT_LIFETIME_SECONDS = 12 * 60 * 60;
+
+async function importVapidPrivateKey(privateJwk) {
+  return crypto.subtle.importKey(
+    "jwk",
+    privateJwk,
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign"],
+  );
+}
+
+// Builds the `Authorization: vapid t=<jwt>, k=<publicKey>` header Web Push
+// services expect (RFC 8292). No payload/encryption involved -- pushes are
+// sent empty, so there's nothing here beyond identifying our server.
+export async function buildVapidAuthorizationHeader({
+  endpoint,
+  privateJwk,
+  publicKey,
+  subject,
+}) {
+  const origin = new URL(endpoint).origin;
+  const privateKey = await importVapidPrivateKey(privateJwk);
+  const now = Math.floor(Date.now() / 1000);
+  const header = { typ: "JWT", alg: "ES256" };
+  const payload = {
+    aud: origin,
+    exp: now + VAPID_JWT_LIFETIME_SECONDS,
+    sub: subject,
+  };
+
+  const headerB64 = base64UrlEncode(encodeUtf8(JSON.stringify(header)));
+  const payloadB64 = base64UrlEncode(encodeUtf8(JSON.stringify(payload)));
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const signature = await crypto.subtle.sign(
+    { name: "ECDSA", hash: "SHA-256" },
+    privateKey,
+    encodeUtf8(signingInput),
+  );
+  const jwt = `${signingInput}.${base64UrlEncode(signature)}`;
+
+  return `vapid t=${jwt}, k=${publicKey}`;
+}

--- a/functions/oauth/assertion.js
+++ b/functions/oauth/assertion.js
@@ -1,19 +1,8 @@
 // Signs OAuth client assertions (private_key_jwt)
 
+import { base64UrlEncode, encodeUtf8 } from "../_lib/dpopVerify.js";
+
 const ASSERTION_LIFETIME_SECONDS = 60;
-
-function base64UrlEncode(buffer) {
-  const bytes = new Uint8Array(buffer);
-  let binary = "";
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
-}
-
-function encodeUtf8(str) {
-  return new TextEncoder().encode(str);
-}
 
 function errorResponse(status, error) {
   return Response.json({ error }, { status });

--- a/functions/push/relay.js
+++ b/functions/push/relay.js
@@ -1,0 +1,105 @@
+import {
+  verifyIdentity,
+  IdentityVerificationError,
+} from "../_lib/dpopVerify.js";
+import { subscriptionPrefix, throttleKey } from "../_lib/kvKeys.js";
+import { buildVapidAuthorizationHeader } from "../_lib/vapid.js";
+
+const THROTTLE_TTL_SECONDS = 60; // KV enforces a 60s minimum expirationTtl
+const PUSH_TTL_SECONDS = 60 * 60 * 24; // 1 day, per RFC 8030 TTL header
+
+function errorResponse(status, error) {
+  return Response.json({ error }, { status });
+}
+
+export async function onRequestPost({ request, env }) {
+  if (!env.PUSH_SUBSCRIPTIONS) {
+    return errorResponse(501, "not_configured");
+  }
+  if (!env.VAPID_PRIVATE_JWK || !env.VAPID_PUBLIC_KEY || !env.VAPID_SUBJECT) {
+    return errorResponse(501, "not_configured");
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse(400, "invalid_request_body");
+  }
+  const { verificationUrl, accessToken, dpopProof, callerEndpoint } =
+    body ?? {};
+
+  let identity;
+  try {
+    identity = await verifyIdentity({
+      verificationUrl,
+      accessToken,
+      dpopProof,
+    });
+  } catch (error) {
+    if (error instanceof IdentityVerificationError) {
+      return errorResponse(401, error.code);
+    }
+    throw error;
+  }
+  if (identity.needsNonce) {
+    return Response.json(
+      { error: "use_dpop_nonce", nonce: identity.nonce },
+      { status: 428 },
+    );
+  }
+  const { did } = identity;
+
+  const throttle = throttleKey("relay", did);
+  if (await env.PUSH_SUBSCRIPTIONS.get(throttle)) {
+    return errorResponse(429, "rate_limited");
+  }
+  await env.PUSH_SUBSCRIPTIONS.put(throttle, "1", {
+    expirationTtl: THROTTLE_TTL_SECONDS,
+  });
+
+  const privateJwk = JSON.parse(env.VAPID_PRIVATE_JWK);
+  const list = await env.PUSH_SUBSCRIPTIONS.list({
+    prefix: subscriptionPrefix(did),
+  });
+
+  await Promise.all(
+    list.keys.map(async (key) => {
+      const raw = await env.PUSH_SUBSCRIPTIONS.get(key.name);
+      if (!raw) return;
+      let stored;
+      try {
+        stored = JSON.parse(raw);
+      } catch {
+        return;
+      }
+      const { subscription } = stored;
+      if (!subscription?.endpoint || subscription.endpoint === callerEndpoint) {
+        return;
+      }
+      try {
+        const authorization = await buildVapidAuthorizationHeader({
+          endpoint: subscription.endpoint,
+          privateJwk,
+          publicKey: env.VAPID_PUBLIC_KEY,
+          subject: env.VAPID_SUBJECT,
+        });
+        const pushResponse = await fetch(subscription.endpoint, {
+          method: "POST",
+          headers: {
+            Authorization: authorization,
+            TTL: String(PUSH_TTL_SECONDS),
+            "Content-Length": "0",
+          },
+        });
+        if (pushResponse.status === 404 || pushResponse.status === 410) {
+          await env.PUSH_SUBSCRIPTIONS.delete(key.name);
+        }
+      } catch (error) {
+        console.error("push relay failed for", key.name, error);
+      }
+    }),
+  );
+
+  return Response.json({ ok: true });
+}

--- a/functions/push/subscribe.js
+++ b/functions/push/subscribe.js
@@ -1,0 +1,69 @@
+import {
+  verifyIdentity,
+  IdentityVerificationError,
+} from "../_lib/dpopVerify.js";
+import { subscriptionKey, throttleKey } from "../_lib/kvKeys.js";
+
+// KV storage isn't request-fresh, so keep subscriptions well under
+// PushSubscription's own typical lifetime and let the client resubscribe.
+const SUBSCRIPTION_TTL_SECONDS = 60 * 60 * 24 * 60; // 60 days
+const THROTTLE_TTL_SECONDS = 60; // KV enforces a 60s minimum expirationTtl
+
+function errorResponse(status, error) {
+  return Response.json({ error }, { status });
+}
+
+export async function onRequestPost({ request, env }) {
+  if (!env.PUSH_SUBSCRIPTIONS) {
+    return errorResponse(501, "not_configured");
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse(400, "invalid_request_body");
+  }
+  const { verificationUrl, accessToken, dpopProof, subscription } = body ?? {};
+  if (!subscription?.endpoint || !subscription?.keys) {
+    return errorResponse(400, "invalid_subscription");
+  }
+
+  let identity;
+  try {
+    identity = await verifyIdentity({
+      verificationUrl,
+      accessToken,
+      dpopProof,
+    });
+  } catch (error) {
+    if (error instanceof IdentityVerificationError) {
+      return errorResponse(401, error.code);
+    }
+    throw error;
+  }
+  if (identity.needsNonce) {
+    return Response.json(
+      { error: "use_dpop_nonce", nonce: identity.nonce },
+      { status: 428 },
+    );
+  }
+  const { did } = identity;
+
+  const throttle = throttleKey("subscribe", did);
+  if (await env.PUSH_SUBSCRIPTIONS.get(throttle)) {
+    return errorResponse(429, "rate_limited");
+  }
+  await env.PUSH_SUBSCRIPTIONS.put(throttle, "1", {
+    expirationTtl: THROTTLE_TTL_SECONDS,
+  });
+
+  const key = await subscriptionKey(did, subscription.endpoint);
+  await env.PUSH_SUBSCRIPTIONS.put(
+    key,
+    JSON.stringify({ subscription, createdAt: Date.now() }),
+    { expirationTtl: SUBSCRIPTION_TTL_SECONDS },
+  );
+
+  return Response.json({ ok: true });
+}

--- a/functions/push/unsubscribe.js
+++ b/functions/push/unsubscribe.js
@@ -1,0 +1,51 @@
+import {
+  verifyIdentity,
+  IdentityVerificationError,
+} from "../_lib/dpopVerify.js";
+import { subscriptionKey } from "../_lib/kvKeys.js";
+
+function errorResponse(status, error) {
+  return Response.json({ error }, { status });
+}
+
+export async function onRequestPost({ request, env }) {
+  if (!env.PUSH_SUBSCRIPTIONS) {
+    return errorResponse(501, "not_configured");
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse(400, "invalid_request_body");
+  }
+  const { verificationUrl, accessToken, dpopProof, endpoint } = body ?? {};
+  if (!endpoint) {
+    return errorResponse(400, "missing_endpoint");
+  }
+
+  let identity;
+  try {
+    identity = await verifyIdentity({
+      verificationUrl,
+      accessToken,
+      dpopProof,
+    });
+  } catch (error) {
+    if (error instanceof IdentityVerificationError) {
+      return errorResponse(401, error.code);
+    }
+    throw error;
+  }
+  if (identity.needsNonce) {
+    return Response.json(
+      { error: "use_dpop_nonce", nonce: identity.nonce },
+      { status: 428 },
+    );
+  }
+
+  const key = await subscriptionKey(identity.did, endpoint);
+  await env.PUSH_SUBSCRIPTIONS.delete(key);
+
+  return Response.json({ ok: true });
+}

--- a/functions/push/vapid-public-key.js
+++ b/functions/push/vapid-public-key.js
@@ -1,0 +1,10 @@
+// Trivial capability probe: the client uses this to decide whether to show
+// the cross-device relay toggle at all, without needing to know in advance
+// whether this deployment has Tier 2 configured.
+
+export async function onRequestGet({ env }) {
+  if (!env.PUSH_SUBSCRIPTIONS || !env.VAPID_PUBLIC_KEY) {
+    return Response.json({ error: "not_configured" }, { status: 501 });
+  }
+  return Response.json({ key: env.VAPID_PUBLIC_KEY });
+}

--- a/scripts/generate-vapid-keypair.js
+++ b/scripts/generate-vapid-keypair.js
@@ -1,0 +1,28 @@
+const { publicKey, privateKey } = await crypto.subtle.generateKey(
+  { name: "ECDSA", namedCurve: "P-256" },
+  true,
+  ["sign", "verify"],
+);
+
+function base64UrlEncode(buffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+const publicKeyRaw = await crypto.subtle.exportKey("raw", publicKey);
+const privateJwk = await crypto.subtle.exportKey("jwk", privateKey);
+
+console.log("VAPID_PUBLIC_KEY (build variable):");
+console.log(base64UrlEncode(publicKeyRaw));
+console.log("");
+console.log("VAPID_PRIVATE_JWK (secret — do not commit):");
+console.log(JSON.stringify(privateJwk));
+console.log("");
+console.log(
+  "VAPID_SUBJECT (build variable — a mailto: or https: contact, required by RFC 8292):",
+);
+console.log("mailto:you@example.com");

--- a/src/_routes.json
+++ b/src/_routes.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "include": ["/js/*", "/css/*", "/img/*", "/oauth/*"],
+  "include": ["/js/*", "/css/*", "/img/*", "/oauth/*", "/push/*"],
   "exclude": []
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -24,6 +24,7 @@ import settingsMutedWordsView from "/js/views/settings/mutedWords.view.js";
 import settingsBlockedAccountsView from "/js/views/settings/blockedAccounts.view.js";
 import settingsMutedAccountsView from "/js/views/settings/mutedAccounts.view.js";
 import settingsAdvancedView from "/js/views/settings/advanced.view.js";
+import settingsNotificationsView from "/js/views/settings/notifications.view.js";
 import installedPluginsView from "/js/views/installedPlugins.view.js";
 import pluginSettingsView from "/js/views/pluginSettings.view.js";
 import communityPluginsView from "/js/views/communityPlugins.view.js";
@@ -42,6 +43,8 @@ import { Api } from "/js/api.js";
 import { auth } from "/js/auth.js";
 import { NotificationService } from "/js/notificationService.js";
 import { ChatNotificationService } from "/js/chatNotificationService.js";
+import { SystemNotificationService } from "/js/systemNotificationService.js";
+import { PushSubscriptionService } from "/js/push/pushSubscriptionService.js";
 import { PostComposerService } from "/js/postComposerService.js";
 import { AccountSwitcherService } from "/js/accountSwitcherService.js";
 import { ReportService } from "/js/reportService.js";
@@ -118,6 +121,17 @@ export async function main() {
   const chatNotificationService = session
     ? new ChatNotificationService(api)
     : null;
+  const pushSubscriptionService = session
+    ? new PushSubscriptionService(session)
+    : null;
+  const systemNotificationService =
+    notificationService && chatNotificationService
+      ? new SystemNotificationService(
+          notificationService,
+          chatNotificationService,
+          pushSubscriptionService,
+        )
+      : null;
   const postComposerService = session
     ? new PostComposerService(dataLayer, identityResolver, pluginService, {
         draftsEnabled: await checkDraftsEnabled(),
@@ -191,6 +205,8 @@ export async function main() {
     identityResolver,
     notificationService,
     chatNotificationService,
+    systemNotificationService,
+    pushSubscriptionService,
     postComposerService,
     accountSwitcherService,
     reportService,
@@ -231,6 +247,15 @@ export async function main() {
         reload: true,
       });
     });
+  }
+
+  if (systemNotificationService) {
+    effect(
+      () => {
+        systemNotificationService.checkForUpdates();
+      },
+      { debugName: "systemNotifications" },
+    );
   }
 
   router.addRoute(["/", "/intent/compose"], () => homeView, {
@@ -305,6 +330,11 @@ export async function main() {
   router.addRoute(
     "/settings/appearance",
     () => settingsAppearanceView,
+    settingsRouteOptions,
+  );
+  router.addRoute(
+    "/settings/notifications",
+    () => settingsNotificationsView,
     settingsRouteOptions,
   );
   router.addRoute(

--- a/src/js/oauth.js
+++ b/src/js/oauth.js
@@ -489,6 +489,34 @@ export class Session {
     return this.sessionData.serviceEndpoint;
   }
 
+  // Builds a DPoP-proofed `{ accessToken, dpopProof }` pair for a specific
+  // method/url, without actually performing the request. Used to let a
+  // server we don't otherwise trust (e.g. the push-notification relay
+  // function) proxy a single, narrowly-scoped call to our own PDS as proof
+  // of current identity, without ever handing it a usable credential of its
+  // own. Pass `nonce` to retry after a server-reported `use_dpop_nonce`.
+  async buildDpopProof(method, url, { nonce = null } = {}) {
+    if (Date.now() > this.sessionData.expiresAt - 60000) {
+      if (!this.pendingRefresh) {
+        this.pendingRefresh = this.refreshToken().finally(() => {
+          this.pendingRefresh = null;
+        });
+      }
+      await this.pendingRefresh;
+    }
+    const accessToken = this.sessionData.accessToken;
+    const origin = new URL(url).origin;
+    const effectiveNonce =
+      nonce ?? this.dpopRequests.nonces.get(origin) ?? null;
+    const dpopProof = await this.dpopRequests.createProof(
+      method,
+      url,
+      effectiveNonce,
+      accessToken,
+    );
+    return { accessToken, dpopProof };
+  }
+
   get scope() {
     return this.sessionData.scope ?? null;
   }

--- a/src/js/push/pushSubscriptionService.js
+++ b/src/js/push/pushSubscriptionService.js
@@ -1,0 +1,140 @@
+import { isNative } from "/js/utils.js";
+
+const SW_URL = "/sw.js";
+const RELAY_STORAGE_KEY = "system-notifications-relay-enabled";
+const GET_SESSION_PATH = "/xrpc/com.atproto.server.getSession";
+
+function base64UrlToUint8Array(base64Url) {
+  const padding = "=".repeat((4 - (base64Url.length % 4)) % 4);
+  const base64 = (base64Url + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(base64);
+  const output = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) {
+    output[i] = raw.charCodeAt(i);
+  }
+  return output;
+}
+
+// Cross-device relay (Tier 2): a device with Impro open relays a real push
+// to the user's other, possibly fully-closed devices. The server never
+// holds a login credential -- each request proves current identity by
+// having the browser generate a DPoP proof for a call to its own PDS's
+// getSession, which our function proxies through and trusts (see
+// functions/_lib/dpopVerify.js and Session.buildDpopProof in oauth.js).
+export class PushSubscriptionService {
+  constructor(session) {
+    this.session = session;
+  }
+
+  get isSupported() {
+    return (
+      !isNative() &&
+      typeof navigator !== "undefined" &&
+      "serviceWorker" in navigator &&
+      typeof window !== "undefined" &&
+      "PushManager" in window &&
+      typeof this.session?.buildDpopProof === "function"
+    );
+  }
+
+  get isEnabled() {
+    return localStorage.getItem(RELAY_STORAGE_KEY) === "true";
+  }
+
+  // Returns the deployment's VAPID public key, or null if this deployment
+  // hasn't configured Tier 2 (or the browser can't support it) -- the
+  // settings UI uses this to decide whether to show the relay toggle.
+  async probeAvailability() {
+    if (!this.isSupported) return null;
+    try {
+      const response = await fetch("/push/vapid-public-key");
+      if (!response.ok) return null;
+      const { key } = await response.json();
+      return key ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  async _verificationCredentials(nonce = null) {
+    const verificationUrl = `${this.session.serviceEndpoint}${GET_SESSION_PATH}`;
+    const { accessToken, dpopProof } = await this.session.buildDpopProof(
+      "GET",
+      verificationUrl,
+      { nonce },
+    );
+    return { verificationUrl, accessToken, dpopProof };
+  }
+
+  async _postWithNonceRetry(url, extraBody) {
+    const post = async (nonce) => {
+      const credentials = await this._verificationCredentials(nonce);
+      return fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...credentials, ...extraBody }),
+      });
+    };
+    let response = await post(null);
+    if (response.status === 428) {
+      const { nonce } = await response.json();
+      response = await post(nonce);
+    }
+    return response;
+  }
+
+  async subscribe(vapidPublicKey) {
+    if (!this.isSupported) return false;
+    await navigator.serviceWorker.register(SW_URL);
+    const registration = await navigator.serviceWorker.ready;
+    const subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: base64UrlToUint8Array(vapidPublicKey),
+    });
+    let response;
+    try {
+      response = await this._postWithNonceRetry("/push/subscribe", {
+        subscription: subscription.toJSON(),
+      });
+    } catch (error) {
+      await subscription.unsubscribe().catch(() => {});
+      throw error;
+    }
+    if (!response.ok) {
+      await subscription.unsubscribe().catch(() => {});
+      return false;
+    }
+    localStorage.setItem(RELAY_STORAGE_KEY, "true");
+    return true;
+  }
+
+  async unsubscribe() {
+    localStorage.removeItem(RELAY_STORAGE_KEY);
+    if (!this.isSupported) return;
+    const registration = await navigator.serviceWorker.getRegistration(SW_URL);
+    const subscription = await registration?.pushManager.getSubscription();
+    if (!subscription) return;
+    const endpoint = subscription.endpoint;
+    await subscription.unsubscribe().catch(() => {});
+    try {
+      await this._postWithNonceRetry("/push/unsubscribe", { endpoint });
+    } catch (error) {
+      console.warn("push unsubscribe failed", error);
+    }
+  }
+
+  async relay() {
+    if (!this.isEnabled || !this.isSupported) return;
+    try {
+      const registration =
+        await navigator.serviceWorker.getRegistration(SW_URL);
+      const subscription = await registration?.pushManager.getSubscription();
+      if (!subscription) return;
+      await this._postWithNonceRetry("/push/relay", {
+        callerEndpoint: subscription.endpoint,
+      });
+    } catch (error) {
+      console.warn("push relay failed", error);
+    }
+  }
+}

--- a/src/js/systemNotificationService.js
+++ b/src/js/systemNotificationService.js
@@ -1,0 +1,100 @@
+const STORAGE_KEY = "system-notifications-enabled";
+const ICON_URL = "/img/impro-logo-192.png";
+
+export class SystemNotificationService {
+  constructor(
+    notificationService,
+    chatNotificationService,
+    pushSubscriptionService = null,
+  ) {
+    this.notificationService = notificationService;
+    this.chatNotificationService = chatNotificationService;
+    this.pushSubscriptionService = pushSubscriptionService;
+    this._lastSeenActivityCount =
+      notificationService.$numNotifications.get() ?? 0;
+    this._lastSeenChatCount =
+      chatNotificationService.$numNotifications.get() ?? 0;
+  }
+
+  get isSupported() {
+    return typeof Notification !== "undefined";
+  }
+
+  get isEnabled() {
+    return localStorage.getItem(STORAGE_KEY) === "true";
+  }
+
+  get permissionState() {
+    return this.isSupported ? Notification.permission : "unsupported";
+  }
+
+  async requestPermission() {
+    if (!this.isSupported) return "unsupported";
+    const result = await Notification.requestPermission();
+    if (result === "granted") {
+      localStorage.setItem(STORAGE_KEY, "true");
+    }
+    return result;
+  }
+
+  disable() {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+
+  notify({ title, body, tag, url }) {
+    if (
+      !this.isSupported ||
+      !this.isEnabled ||
+      Notification.permission !== "granted" ||
+      this.notificationService.isSnoozed
+    ) {
+      return;
+    }
+    const notification = new Notification(title, {
+      body,
+      icon: ICON_URL,
+      badge: ICON_URL,
+      tag,
+    });
+    notification.onclick = () => {
+      window.focus();
+      window.location.href = url;
+      notification.close();
+    };
+    if (this.pushSubscriptionService?.isEnabled) {
+      this.pushSubscriptionService.relay();
+    }
+  }
+
+  checkForUpdates() {
+    const activityCount = this.notificationService.$numNotifications.get() ?? 0;
+    const chatCount = this.chatNotificationService.$numNotifications.get() ?? 0;
+
+    if (activityCount > this._lastSeenActivityCount) {
+      this.notify({
+        title: "New activity on Impro",
+        body:
+          activityCount === 1
+            ? "You have 1 new notification"
+            : `You have ${activityCount} new notifications`,
+        tag: "impro-activity",
+        url: "/notifications",
+      });
+    }
+
+    if (chatCount > this._lastSeenChatCount) {
+      this.notify({
+        title: "New message on Impro",
+        body:
+          chatCount === 1
+            ? "You have 1 unread conversation"
+            : `You have ${chatCount} unread conversations`,
+        tag: "impro-chat",
+        url: "/messages",
+      });
+    }
+
+    this._lastSeenActivityCount = activityCount;
+    this._lastSeenChatCount = chatCount;
+  }
+}

--- a/src/js/views/settings.view.js
+++ b/src/js/views/settings.view.js
@@ -2,6 +2,7 @@ import { View } from "/js/views/view.js";
 import { pageEffect, bindToPage, bindPageTitle } from "/js/router.js";
 import { html, render } from "/js/lib/lit-html.js";
 import { eyeIconTemplate } from "/js/templates/icons/eyeIcon.template.js";
+import { notificationsIconTemplate } from "/js/templates/icons/notificationsIcon.template.js";
 import { eyeSlashIconTemplate } from "/js/templates/icons/eyeSlashIcon.template.js";
 import { mutedWordIconTemplate } from "/js/templates/icons/mutedWordIcon.template.js";
 import { restrictedIconTemplate } from "/js/templates/icons/restrictedIcon.template.js";
@@ -187,6 +188,12 @@ class SettingsView extends View {
         icon: eyeIconTemplate,
         label: "Appearance",
         url: "/settings/appearance",
+      },
+      {
+        key: "notifications",
+        icon: notificationsIconTemplate,
+        label: "Notifications",
+        url: "/settings/notifications",
       },
       {
         key: "muted-words",

--- a/src/js/views/settings/notifications.view.js
+++ b/src/js/views/settings/notifications.view.js
@@ -1,0 +1,181 @@
+import { View } from "/js/views/view.js";
+import { html, render } from "/js/lib/lit-html.js";
+import { pageEffect, bindToPage, bindPageTitle } from "/js/router.js";
+import { headerTemplate } from "/js/templates/header.template.js";
+import { auth } from "/js/auth.js";
+import { confirmModal } from "/js/modals/confirm.modal.js";
+import { showToast } from "/js/toasts.js";
+import { Signal } from "/js/signals.js";
+import "/js/components/toggle-switch.js";
+
+class SettingsNotificationsView extends View {
+  async render({
+    root,
+    router,
+    layout,
+    context: { systemNotificationService, pushSubscriptionService },
+  }) {
+    await auth.requireAuth();
+
+    const $enabled = new Signal.State(
+      systemNotificationService?.isEnabled ?? false,
+    );
+    const $relayEnabled = new Signal.State(
+      pushSubscriptionService?.isEnabled ?? false,
+    );
+    const $relayPending = new Signal.State(false);
+    // null until the capability probe resolves; stays null forever on
+    // deployments that haven't configured Tier 2, which hides the toggle.
+    const $vapidKey = new Signal.State(null);
+
+    if (pushSubscriptionService) {
+      pushSubscriptionService.probeAvailability().then((key) => {
+        $vapidKey.set(key);
+      });
+    }
+
+    async function handleToggle(checked) {
+      if (!systemNotificationService) return;
+      if (!checked) {
+        systemNotificationService.disable();
+        $enabled.set(false);
+        return;
+      }
+      const confirmed = await confirmModal(
+        "Impro will ask your browser for permission to show notifications. You can turn this off again at any time.",
+        { title: "Enable notifications?", confirmButtonText: "Continue" },
+      );
+      if (!confirmed) return;
+      const result = await systemNotificationService.requestPermission();
+      if (result === "granted") {
+        $enabled.set(true);
+      } else {
+        $enabled.set(false);
+        if (result === "denied") {
+          showToast(
+            "Notifications are blocked for this site. Re-enable them in your browser's site settings.",
+            { style: "error" },
+          );
+        }
+      }
+    }
+
+    async function handleRelayToggle(checked) {
+      if (!pushSubscriptionService || $relayPending.get()) return;
+      $relayPending.set(true);
+      try {
+        if (!checked) {
+          await pushSubscriptionService.unsubscribe();
+          $relayEnabled.set(false);
+          return;
+        }
+        const vapidPublicKey = $vapidKey.get();
+        if (!vapidPublicKey) return;
+        const ok = await pushSubscriptionService.subscribe(vapidPublicKey);
+        $relayEnabled.set(ok);
+        if (!ok) {
+          showToast("Couldn't enable notifications on your other devices.", {
+            style: "error",
+          });
+        }
+      } catch (error) {
+        console.error(error);
+        $relayEnabled.set(false);
+        showToast("Couldn't enable notifications on your other devices.", {
+          style: "error",
+        });
+      } finally {
+        $relayPending.set(false);
+      }
+    }
+
+    bindToPage(root, layout, "active-nav-click", (event) => {
+      event.preventDefault();
+      router.go("/settings");
+    });
+
+    bindPageTitle(root, () => "Notifications");
+
+    pageEffect(root, () => {
+      const enabled = $enabled.get();
+      const isSupported = systemNotificationService?.isSupported ?? false;
+      const permissionState =
+        systemNotificationService?.permissionState ?? "unsupported";
+      const isDenied = permissionState === "denied";
+
+      let description =
+        "Get notified when you have new activity or messages while Impro is open in a tab or window.";
+      if (!isSupported) {
+        description = "Your browser doesn't support notifications.";
+      } else if (isDenied) {
+        description =
+          "Notifications are blocked for this site. Re-enable them in your browser's site settings to turn this on.";
+      }
+
+      const vapidKey = $vapidKey.get();
+      const relayEnabled = $relayEnabled.get();
+      const relayPending = $relayPending.get();
+
+      render(
+        html`<div id="settings-notifications-view">
+          ${headerTemplate({
+            title: "Notifications",
+            backButtonFallbackRoute: "/settings",
+          })}
+          <main>
+            <section
+              class="setting-item"
+              data-testid="settings-section-system-notifications"
+            >
+              <div class="setting-item-info">
+                <h2 class="setting-item-name">Enable notifications</h2>
+                <p class="setting-item-desc">${description}</p>
+              </div>
+              <div class="setting-item-control">
+                <toggle-switch
+                  data-testid="system-notifications-toggle"
+                  label="Enable notifications"
+                  ?checked=${enabled}
+                  ?disabled=${!isSupported || isDenied}
+                  @change=${(event) => handleToggle(event.detail.checked)}
+                ></toggle-switch>
+              </div>
+            </section>
+            ${vapidKey
+              ? html`<section
+                  class="setting-item"
+                  data-testid="settings-section-relay-notifications"
+                >
+                  <div class="setting-item-info">
+                    <h2 class="setting-item-name">Notify my other devices</h2>
+                    <p class="setting-item-desc">
+                      ${enabled
+                        ? "When this device sees new activity, also send a notification to your other signed-in devices, even if they're closed."
+                        : "Enable notifications above first."}
+                    </p>
+                  </div>
+                  <div class="setting-item-control">
+                    <toggle-switch
+                      data-testid="relay-notifications-toggle"
+                      label="Notify my other devices"
+                      ?checked=${relayEnabled}
+                      ?disabled=${!enabled || relayPending}
+                      @change=${(event) =>
+                        handleRelayToggle(event.detail.checked)}
+                    ></toggle-switch>
+                  </div>
+                </section>`
+              : null}
+          </main>
+        </div>`,
+        root,
+      );
+    });
+
+    root.addEventListener("page-restore", () => {
+      window.scrollTo(0, 0);
+    });
+  }
+}
+
+export default new SettingsNotificationsView();

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,0 +1,37 @@
+// Service worker for Web Push notifications (Tier 2 / cross-device relay).
+// Push messages are sent with no payload (see functions/push/relay.js), so
+// there's nothing to decrypt here — just show a generic notification.
+
+const NOTIFICATION_ICON = "/img/impro-logo-192.png";
+
+self.addEventListener("push", (event) => {
+  event.waitUntil(
+    self.registration.showNotification("New activity on Impro", {
+      body: "You have new activity on one of your other devices.",
+      icon: NOTIFICATION_ICON,
+      badge: NOTIFICATION_ICON,
+      tag: "impro-push",
+      data: { url: "/notifications" },
+    }),
+  );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const url = event.notification.data?.url ?? "/";
+  event.waitUntil(
+    (async () => {
+      const clientsList = await clients.matchAll({
+        type: "window",
+        includeUncontrolled: true,
+      });
+      for (const client of clientsList) {
+        if (!("focus" in client)) continue;
+        await client.focus();
+        if ("navigate" in client) await client.navigate(url);
+        return;
+      }
+      await clients.openWindow(url);
+    })(),
+  );
+});

--- a/tests/e2e/specs/views/settings.view.test.js
+++ b/tests/e2e/specs/views/settings.view.test.js
@@ -19,12 +19,15 @@ test.describe("Settings view", () => {
     );
 
     const nav = view.locator(".vertical-nav");
-    // 5 menu items + Switch account toggle + Sign out (accounts list is collapsed by default)
-    await expect(nav.locator(".vertical-nav-item")).toHaveCount(7, {
+    // 6 menu items + Switch account toggle + Sign out (accounts list is collapsed by default)
+    await expect(nav.locator(".vertical-nav-item")).toHaveCount(8, {
       timeout: 10000,
     });
     await expect(
       nav.locator('[data-testid="settings-nav-appearance"]'),
+    ).toBeVisible();
+    await expect(
+      nav.locator('[data-testid="settings-nav-notifications"]'),
     ).toBeVisible();
     await expect(
       nav.locator('[data-testid="settings-nav-muted-words"]'),

--- a/tests/e2e/specs/views/settingsNotifications.view.test.js
+++ b/tests/e2e/specs/views/settingsNotifications.view.test.js
@@ -1,0 +1,148 @@
+import { test, expect } from "../../base.js";
+import { login } from "../../helpers.js";
+import { MockServer } from "../../mockServer.js";
+
+// Stubs the Notification API so permission prompts are deterministic in CI
+// (headless browsers have no real OS notification center to grant/deny).
+// `initial` is the permission state on page load; `onPrompt` is what the
+// mock resolves to the first time requestPermission() is actually called
+// (only takes effect starting from "default" -- real browsers never
+// re-prompt once a decision has already been made).
+async function stubNotificationPermission(
+  page,
+  { initial = "default", onPrompt = "granted" } = {},
+) {
+  await page.addInitScript(
+    ({ initialPermission, promptResult }) => {
+      class MockNotification {
+        static permission = initialPermission;
+        static async requestPermission() {
+          if (MockNotification.permission === "default") {
+            MockNotification.permission = promptResult;
+          }
+          return MockNotification.permission;
+        }
+        constructor() {}
+        close() {}
+      }
+      window.Notification = MockNotification;
+    },
+    { initialPermission: initial, promptResult: onPrompt },
+  );
+}
+
+test.describe("Settings > Notifications view", () => {
+  test("toggle starts unchecked and enables after granting permission", async ({
+    page,
+  }) => {
+    const mockServer = new MockServer();
+    await mockServer.setup(page);
+    await stubNotificationPermission(page, {
+      initial: "default",
+      onPrompt: "granted",
+    });
+    await login(page);
+    await page.goto("/settings/notifications");
+
+    const toggle = page.locator('[data-testid="system-notifications-toggle"]');
+    await expect(toggle).toBeVisible({ timeout: 10000 });
+    await expect(toggle).not.toHaveAttribute("checked", "");
+
+    await toggle.click();
+
+    const confirmModal = page.locator('[data-testid="confirm-modal"]');
+    await expect(confirmModal).toBeVisible();
+    await confirmModal.locator('[data-testid="modal-confirm-button"]').click();
+
+    await expect(toggle).toHaveAttribute("checked", "", { timeout: 10000 });
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          localStorage.getItem("system-notifications-enabled"),
+        ),
+      )
+      .toBe("true");
+  });
+
+  test("declining the confirm dialog leaves notifications disabled", async ({
+    page,
+  }) => {
+    const mockServer = new MockServer();
+    await mockServer.setup(page);
+    await stubNotificationPermission(page, { initial: "default" });
+    await login(page);
+    await page.goto("/settings/notifications");
+
+    const toggle = page.locator('[data-testid="system-notifications-toggle"]');
+    await expect(toggle).toBeVisible({ timeout: 10000 });
+
+    await toggle.click();
+
+    const confirmModal = page.locator('[data-testid="confirm-modal"]');
+    await expect(confirmModal).toBeVisible();
+    await confirmModal.locator('[data-testid="modal-cancel-button"]').click();
+
+    await expect(toggle).not.toHaveAttribute("checked", "");
+    expect(
+      await page.evaluate(() =>
+        localStorage.getItem("system-notifications-enabled"),
+      ),
+    ).toBeNull();
+  });
+
+  test("shows an error toast when the browser denies permission", async ({
+    page,
+  }) => {
+    const mockServer = new MockServer();
+    await mockServer.setup(page);
+    await stubNotificationPermission(page, {
+      initial: "default",
+      onPrompt: "denied",
+    });
+    await login(page);
+    await page.goto("/settings/notifications");
+
+    const toggle = page.locator('[data-testid="system-notifications-toggle"]');
+    await expect(toggle).toBeVisible({ timeout: 10000 });
+
+    await toggle.click();
+    await page
+      .locator(
+        '[data-testid="confirm-modal"] [data-testid="modal-confirm-button"]',
+      )
+      .click();
+
+    await expect(page.locator('[data-testid="toast"]')).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(toggle).not.toHaveAttribute("checked", "");
+  });
+
+  test("turning the toggle off clears the stored preference without a confirm dialog", async ({
+    page,
+  }) => {
+    const mockServer = new MockServer();
+    await mockServer.setup(page);
+    await stubNotificationPermission(page, { initial: "granted" });
+    await login(page);
+    await page.addInitScript(() => {
+      localStorage.setItem("system-notifications-enabled", "true");
+    });
+    await page.goto("/settings/notifications");
+
+    const toggle = page.locator('[data-testid="system-notifications-toggle"]');
+    await expect(toggle).toHaveAttribute("checked", "", { timeout: 10000 });
+
+    await toggle.click();
+
+    await expect(page.locator('[data-testid="confirm-modal"]')).toHaveCount(0);
+    await expect(toggle).not.toHaveAttribute("checked", "");
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          localStorage.getItem("system-notifications-enabled"),
+        ),
+      )
+      .toBeNull();
+  });
+});

--- a/tests/unit/specs/systemNotificationService.test.js
+++ b/tests/unit/specs/systemNotificationService.test.js
@@ -1,0 +1,254 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { Signal } from "/js/signals.js";
+import { SystemNotificationService } from "/js/systemNotificationService.js";
+
+function createMockNotificationService({
+  numNotifications = 0,
+  isSnoozed = false,
+} = {}) {
+  return {
+    $numNotifications: new Signal.State(numNotifications),
+    isSnoozed,
+  };
+}
+
+function createMockChatNotificationService({ numNotifications = 0 } = {}) {
+  return {
+    $numNotifications: new Signal.State(numNotifications),
+  };
+}
+
+function enable() {
+  localStorage.setItem("system-notifications-enabled", "true");
+}
+
+describe("SystemNotificationService", () => {
+  let instances;
+  let originalNotification;
+
+  beforeEach(() => {
+    instances = [];
+    originalNotification = globalThis.Notification;
+    globalThis.Notification = class {
+      static permission = "granted";
+      static async requestPermission() {
+        return globalThis.Notification.permission;
+      }
+      constructor(title, options) {
+        this.title = title;
+        this.options = options;
+        instances.push(this);
+      }
+      close() {}
+    };
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    globalThis.Notification = originalNotification;
+    localStorage.clear();
+  });
+
+  describe("constructor", () => {
+    it("seeds last-seen counts without firing", () => {
+      const notificationService = createMockNotificationService({
+        numNotifications: 5,
+      });
+      const chatNotificationService = createMockChatNotificationService({
+        numNotifications: 2,
+      });
+      const service = new SystemNotificationService(
+        notificationService,
+        chatNotificationService,
+      );
+      enable();
+
+      service.checkForUpdates();
+
+      assert.deepEqual(instances.length, 0);
+    });
+  });
+
+  describe("checkForUpdates", () => {
+    it("notifies when the activity count increases", () => {
+      const notificationService = createMockNotificationService();
+      const chatNotificationService = createMockChatNotificationService();
+      const service = new SystemNotificationService(
+        notificationService,
+        chatNotificationService,
+      );
+      enable();
+
+      notificationService.$numNotifications.set(3);
+      service.checkForUpdates();
+
+      assert.deepEqual(instances.length, 1);
+      assert.deepEqual(instances[0].options.tag, "impro-activity");
+    });
+
+    it("does not notify again for an unchanged count", () => {
+      const notificationService = createMockNotificationService();
+      const chatNotificationService = createMockChatNotificationService();
+      const service = new SystemNotificationService(
+        notificationService,
+        chatNotificationService,
+      );
+      enable();
+
+      notificationService.$numNotifications.set(3);
+      service.checkForUpdates();
+      service.checkForUpdates();
+
+      assert.deepEqual(instances.length, 1);
+    });
+
+    it("notifies again when the count increases further", () => {
+      const notificationService = createMockNotificationService();
+      const chatNotificationService = createMockChatNotificationService();
+      const service = new SystemNotificationService(
+        notificationService,
+        chatNotificationService,
+      );
+      enable();
+
+      notificationService.$numNotifications.set(3);
+      service.checkForUpdates();
+      notificationService.$numNotifications.set(5);
+      service.checkForUpdates();
+
+      assert.deepEqual(instances.length, 2);
+    });
+
+    it("does not notify when the count decreases", () => {
+      const notificationService = createMockNotificationService({
+        numNotifications: 5,
+      });
+      const chatNotificationService = createMockChatNotificationService();
+      const service = new SystemNotificationService(
+        notificationService,
+        chatNotificationService,
+      );
+      enable();
+
+      notificationService.$numNotifications.set(0);
+      service.checkForUpdates();
+
+      assert.deepEqual(instances.length, 0);
+    });
+
+    it("notifies when the chat count increases", () => {
+      const notificationService = createMockNotificationService();
+      const chatNotificationService = createMockChatNotificationService();
+      const service = new SystemNotificationService(
+        notificationService,
+        chatNotificationService,
+      );
+      enable();
+
+      chatNotificationService.$numNotifications.set(2);
+      service.checkForUpdates();
+
+      assert.deepEqual(instances.length, 1);
+      assert.deepEqual(instances[0].options.tag, "impro-chat");
+    });
+  });
+
+  describe("notify gating", () => {
+    it("does not notify when disabled", () => {
+      const notificationService = createMockNotificationService();
+      const chatNotificationService = createMockChatNotificationService();
+      const service = new SystemNotificationService(
+        notificationService,
+        chatNotificationService,
+      );
+
+      notificationService.$numNotifications.set(3);
+      service.checkForUpdates();
+
+      assert.deepEqual(instances.length, 0);
+    });
+
+    it("does not notify when permission is not granted", () => {
+      const notificationService = createMockNotificationService();
+      const chatNotificationService = createMockChatNotificationService();
+      const service = new SystemNotificationService(
+        notificationService,
+        chatNotificationService,
+      );
+      enable();
+      globalThis.Notification.permission = "default";
+
+      notificationService.$numNotifications.set(3);
+      service.checkForUpdates();
+
+      assert.deepEqual(instances.length, 0);
+    });
+
+    it("does not notify when snoozed", () => {
+      const notificationService = createMockNotificationService({
+        isSnoozed: true,
+      });
+      const chatNotificationService = createMockChatNotificationService();
+      const service = new SystemNotificationService(
+        notificationService,
+        chatNotificationService,
+      );
+      enable();
+
+      notificationService.$numNotifications.set(3);
+      service.checkForUpdates();
+
+      assert.deepEqual(instances.length, 0);
+    });
+  });
+
+  describe("requestPermission", () => {
+    it("sets the storage flag when granted", async () => {
+      const notificationService = createMockNotificationService();
+      const chatNotificationService = createMockChatNotificationService();
+      const service = new SystemNotificationService(
+        notificationService,
+        chatNotificationService,
+      );
+      globalThis.Notification.permission = "granted";
+
+      const result = await service.requestPermission();
+
+      assert.deepEqual(result, "granted");
+      assert.deepEqual(service.isEnabled, true);
+    });
+
+    it("does not set the storage flag when denied", async () => {
+      const notificationService = createMockNotificationService();
+      const chatNotificationService = createMockChatNotificationService();
+      const service = new SystemNotificationService(
+        notificationService,
+        chatNotificationService,
+      );
+      globalThis.Notification.permission = "denied";
+
+      const result = await service.requestPermission();
+
+      assert.deepEqual(result, "denied");
+      assert.deepEqual(service.isEnabled, false);
+    });
+  });
+
+  describe("disable", () => {
+    it("clears the storage flag", () => {
+      const notificationService = createMockNotificationService();
+      const chatNotificationService = createMockChatNotificationService();
+      const service = new SystemNotificationService(
+        notificationService,
+        chatNotificationService,
+      );
+      enable();
+      assert.deepEqual(service.isEnabled, true);
+
+      service.disable();
+
+      assert.deepEqual(service.isEnabled, false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Real system notifications, in two tiers that land together:

- **Open-tab notifications** — real OS `Notification` banners whenever Impro is open in a tab (foreground or background), driven entirely by the existing 10s polling in `NotificationService`/`ChatNotificationService`. No backend, no new dependencies. New Settings → Notifications page with a permission-priming confirm dialog before the browser's own permission prompt.
- **Cross-device relay** — when one signed-in device detects something new via its own open-tab polling, it can relay a real push to your *other* devices, even if those are fully closed. Adds a service worker, Web Push (VAPID) subscriptions, and Cloudflare Pages Functions (`functions/push/*`) backed by Workers KV.

Two things were deliberately ruled out during design:
- **Bluesky's `app.bsky.notification.registerPush`** only forwards a registration to a service DID *you* operate — it doesn't tell a third party when something actually happens, so it wouldn't have saved us from building this.
- **Server-side polling on the user's behalf** — OAuth sessions here are DPoP-bound to a non-extractable, browser-generated key, so a captured refresh token is useless off-browser. Rather than working around that (which would mean the server holding a live, continuously-refreshed session per opted-in user), the relay's identity check instead has the browser generate a single, narrowly-scoped DPoP proof for a call to its own PDS's `com.atproto.server.getSession`, which the Cloudflare Function proxies through and trusts (`functions/_lib/dpopVerify.js`). The server never sees or stores a usable credential.

Push messages are sent payload-less (no `web-push`/aes128gcm dependency needed) — the service worker shows a generic notification and the client already has the real detail from its own polling.

## What needs to be enabled on the Cloudflare side

Nothing is required for Tier 1. Tier 2 needs, per deployment:

- A **Workers KV namespace** bound as `PUSH_SUBSCRIPTIONS` on the Pages project.
- Three project vars/secrets: `VAPID_PUBLIC_KEY` and `VAPID_SUBJECT` (plain vars — public key + a `mailto:`/`https:` contact per RFC 8292) and `VAPID_PRIVATE_JWK` (secret). Generate a keypair with `node scripts/generate-vapid-keypair.js`.
- `/push/*` added to `src/_routes.json`'s `include` list (already done in this PR) — otherwise Cloudflare Pages never invokes those functions at all.

Everything above is optional per-deployment: `functions/push/vapid-public-key.js` is a capability probe the client checks before showing the "Notify my other devices" toggle at all, and every `/push/*` function returns a clean `501` if the KV binding or VAPID secrets aren't configured (same pattern the existing `functions/oauth/assertion.js` already uses for `OAUTH_PRIVATE_JWK`). Deployments that don't set any of this up just silently get Tier 1 only.

None of this needs a `wrangler.toml` committed to the repo — it's deployment-specific (KV namespace IDs, public key) so it's gitignored; generate your own.

### How I set this up on our test deployment, via CLI with a Cloudflare API token

Used `wrangler` (now in the flake's devShell) with `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` env vars set from an API token scoped to Account → Cloudflare Pages → Edit, Account → Workers KV Storage → Edit, and Zone → DNS → Edit (the last only needed because we also wanted to attach a custom domain — skip it if you're fine with the default `*.pages.dev` URL). One note if you create a token with a mix of account- and zone-scoped permissions: Cloudflare tokens use separate *policies* for account-level vs. zone-level resources — put DNS in its own policy rather than trying to select "entire account" and a specific zone in the same one, or you'll silently lose the other permissions.

```sh
# One-time: create the KV namespace and the Pages project
wrangler kv namespace create PUSH_SUBSCRIPTIONS
wrangler pages project create <project-name> --production-branch=main --compatibility-date=<date>

# wrangler.toml (gitignored, not in this repo) in the project root:
#   name = "<project-name>"
#   pages_build_output_dir = "build"
#   compatibility_date = "<date>"
#   [[kv_namespaces]]
#   binding = "PUSH_SUBSCRIPTIONS"
#   id = "<namespace-id-from-above>"
#   [vars]
#   VAPID_PUBLIC_KEY = "<from generate-vapid-keypair.js>"
#   VAPID_SUBJECT = "https://<your-domain>"

npm run build
wrangler pages deploy --project-name=<project-name> --branch=main
wrangler pages secret put VAPID_PRIVATE_JWK --project-name=<project-name>   # paste the private JWK
wrangler pages deploy --project-name=<project-name> --branch=main          # secrets need a redeploy to take effect

# Optional: attach a custom domain (needs the Zone:DNS:Edit permission above)
curl -X POST "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/<project-name>/domains" \
  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" -H "Content-Type: application/json" \
  -d '{"name":"<your-domain>"}'
# then point the domain's DNS record at <project-name>.pages.dev (CNAME, proxied)
```

Live debugging, if something goes wrong: `wrangler pages deployment tail <deployment-id> --project-name=<project-name>` streams real server-side exceptions from the Functions in real time — this is how a genuine bug got caught during testing (see below).

## Testing

- Unit: new `tests/unit/specs/systemNotificationService.test.js` (dedupe, gating on disabled/unpermitted/snoozed, re-fire on further increases). Full suite (4051 tests) passes.
- E2e: new `tests/e2e/specs/views/settingsNotifications.view.test.js` covers the Tier 1 settings toggle flow (grant/deny/cancel permission, disabling), with a `Notification` mock that actually simulates the browser's grant/deny decision rather than just returning a fixed value. Full suite passes locally.
- **Real devices**: tested end-to-end against a live Cloudflare Pages deployment (KV + VAPID configured for real, not mocked) on **Chrome on Android** and **Firefox on Linux (desktop)** — enabled notifications on both, enabled cross-device relay on both, and confirmed a real push notification arrives on one device when the other detects new activity. Caught and fixed a real bug this way: Cloudflare KV enforces a 60-second minimum `expirationTtl`, and the relay/subscribe throttle keys were using 5–10s, which made every throttle KV write fail and take down the whole request. Not something any of the automated tests would catch (KV isn't emulated in the unit/e2e setup), only live testing surfaced it.

### Testing this semi-live yourselves

If you want to poke at a real deployment (rather than just reading the diff), our test site at `impro.7778777.online` (Cloudflare Pages project `impro-test`) has this fully configured — real KV, real VAPID keys, real push delivery. Sign in, go to Settings → Notifications, and both toggles should work end-to-end on any browser/device that supports them (the "Notify my other devices" toggle only appears if your browser supports it and the deployment has Tier 2 configured, which this one does). It's a personal test deployment, not affiliated with impro.social, so feel free to use it for exactly this.
