### PR TITLE
Recognize record links pointing at the current origin

### DIFF
--- a/src/js/dataHelpers.js
+++ b/src/js/dataHelpers.js
@@ -965,6 +965,7 @@ export function getInviteCodeFromUrl(url) {
     );
     if (
       !url.startsWith("/") &&
+      parsed.hostname !== window.location.hostname &&
       !IN_APP_LINK_DOMAINS.includes(parsed.hostname)
     ) {
       return null;

--- a/src/js/embedHelpers.js
+++ b/src/js/embedHelpers.js
@@ -30,7 +30,10 @@ const RECORD_LINK_PATTERNS = [
 export function parseRecordLink(url) {
   try {
     const parsedUrl = new URL(url);
-    if (!IN_APP_LINK_DOMAINS.includes(parsedUrl.hostname)) {
+    if (
+      parsedUrl.hostname !== window.location.hostname &&
+      !IN_APP_LINK_DOMAINS.includes(parsedUrl.hostname)
+    ) {
       return null;
     }
     for (const { pattern, collection } of RECORD_LINK_PATTERNS) {

--- a/tests/unit/specs/dataHelpers.test.js
+++ b/tests/unit/specs/dataHelpers.test.js
@@ -49,6 +49,7 @@ import {
   getPostsFromPostThread,
   getPostsFromFeed,
 } from "/js/dataHelpers.js";
+import { IN_APP_LINK_DOMAINS } from "/js/config.js";
 
 describe("avatarThumbnailUrl", () => {
   it("should convert plain avatar URL to thumbnail URL", () => {
@@ -1830,6 +1831,22 @@ describe("getInviteCodeFromUrl", () => {
       getInviteCodeFromUrl("https://dev.impro.social/chat/abcd1234"),
       "abcd1234",
     );
+  });
+
+  it("accepts a link to the current origin even when it's not in the static domain list", () => {
+    // window.location.hostname is "localhost" in tests, which happens to
+    // already be in IN_APP_LINK_DOMAINS -- remove it so this actually
+    // exercises the same-origin fallback rather than the static list.
+    const index = IN_APP_LINK_DOMAINS.indexOf("localhost");
+    IN_APP_LINK_DOMAINS.splice(index, 1);
+    try {
+      assert.deepEqual(
+        getInviteCodeFromUrl("http://localhost/chat/abcd1234"),
+        "abcd1234",
+      );
+    } finally {
+      IN_APP_LINK_DOMAINS.splice(index, 0, "localhost");
+    }
   });
 
   it("rejects malformed codes", () => {

--- a/tests/unit/specs/embedHelpers.test.js
+++ b/tests/unit/specs/embedHelpers.test.js
@@ -1,6 +1,7 @@
 import { describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
 import { parseRecordLink, resolveRecordFromLink } from "/js/embedHelpers.js";
+import { IN_APP_LINK_DOMAINS } from "/js/config.js";
 import { makeTestDataLayer, stubRecordLinkResolution } from "../testHelpers.js";
 
 describe("parseRecordLink", () => {
@@ -61,6 +62,26 @@ describe("parseRecordLink", () => {
       parseRecordLink("https://example.com/profile/alice.test/post/3abc"),
       null,
     );
+  });
+
+  it("parses a link to the current origin even when it's not in the static domain list", () => {
+    // window.location.hostname is "localhost" in tests, which happens to
+    // already be in IN_APP_LINK_DOMAINS -- remove it so this actually
+    // exercises the same-origin fallback rather than the static list.
+    const index = IN_APP_LINK_DOMAINS.indexOf("localhost");
+    IN_APP_LINK_DOMAINS.splice(index, 1);
+    try {
+      assert.deepEqual(
+        parseRecordLink("http://localhost/profile/alice.test/post/3abc"),
+        {
+          collection: "app.bsky.feed.post",
+          didOrHandle: "alice.test",
+          rkey: "3abc",
+        },
+      );
+    } finally {
+      IN_APP_LINK_DOMAINS.splice(index, 0, "localhost");
+    }
   });
 
   it("returns null for unrelated in-app paths", () => {


### PR DESCRIPTION
## Summary

Pasting a link to a post on any *other* Impro/Bluesky-compatible deployment than `bsky.app`/`impro.social`/`dev.impro.social` into the composer falls back to an external-link card instead of creating a quote-post embed — most noticeably, pasting a link to a post on the exact deployment you're currently using doesn't work.

## Root cause

`parseRecordLink()` (`src/js/embedHelpers.js`, used by the composer to decide quote-post vs. external link) and `getInviteCodeFromUrl()` (`src/js/dataHelpers.js`) both gate on the static `IN_APP_LINK_DOMAINS` allowlist in `src/js/config.js` *before* checking whether the URL's path even matches a known record/invite shape. That list is necessarily finite and can't enumerate every self-hosted or forked deployment.

`app.js`'s in-app-link click interception already handles this correctly, with a same-origin fallback alongside the same domain list:
```js
const currentHostname = window.location.hostname;
...
currentHostname === parsedUrl.hostname || IN_APP_LINK_DOMAINS.includes(parsedUrl.hostname)
```
`parseRecordLink`/`getInviteCodeFromUrl` just never had the same fallback. This PR adds it to both.

## Testing

- New unit tests in both `embedHelpers.test.js` and `dataHelpers.test.js` covering the same-origin fallback specifically (temporarily removing `"localhost"` from `IN_APP_LINK_DOMAINS` within the test so it actually exercises the new branch instead of the pre-existing static-list match). Full suite passes (4041/4041).
- Manually verified on a real self-hosted deployment (not `impro.social`/`dev.impro.social`): pasting a link to a post hosted on that same deployment now creates a quote-post embed instead of falling back to a link card.
