### PR TITLE
Add cross-device push notification relay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@ node_modules
 build
 impro-plugin/docs
 .env
+# Per-deployment Cloudflare Pages config (KV namespace IDs, vars) - not
+# shared across forks/deployments, generate your own via `wrangler pages
+# project create` + `wrangler kv namespace create`.
+wrangler.toml
+wrangler.jsonc
 .context
 tests/e2e/.results
 tests/.artifacts/visual

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ If you notice a bug or feature missing, please open [an issue](https://github.co
 
 Impro uses the [Bluesky API](https://docs.bsky.app/docs/category/http-reference) for authentication and data fetching. Additionally, it uses [Constellation](https://constellation.microcosm.blue/) to populate blocked replies.
 
+Optionally, a deployment can enable cross-device push notifications by configuring a Cloudflare KV binding (`PUSH_SUBSCRIPTIONS`) and VAPID keys (`VAPID_PRIVATE_JWK`, `VAPID_PUBLIC_KEY`, `VAPID_SUBJECT`) — see `scripts/generate-vapid-keypair.js`. Without this configured, notifications still work locally on whichever device has Impro open.
+
 ## Dependencies
 
 Impro uses the following libraries:

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -34,6 +34,9 @@ export default async function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("src/_headers");
   eleventyConfig.addPassthroughCopy("src/_routes.json");
   eleventyConfig.addPassthroughCopy("src/plugin-sandbox.html");
+  // Served at site root (not under /js/) so it gets a stable, unhashed URL
+  // and default max scope; must bypass the src/js/**/*.js cache-busting pass.
+  eleventyConfig.addPassthroughCopy("src/sw.js");
 
   // Prevent sandbox from being treated as a template
   eleventyConfig.ignores.add("src/plugin-sandbox.html");

--- a/functions/_lib/dpopVerify.js
+++ b/functions/_lib/dpopVerify.js
@@ -1,0 +1,88 @@
+// Shared helpers for functions/oauth/assertion.js and functions/push/*.js.
+// Files under functions/_lib/ are not routed by Cloudflare Pages (any path
+// segment starting with "_" is excluded from routing), so this is safe to
+// import from sibling function files without creating an extra endpoint.
+
+export function base64UrlEncode(buffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+export function encodeUtf8(str) {
+  return new TextEncoder().encode(str);
+}
+
+const GET_SESSION_PATH = "/xrpc/com.atproto.server.getSession";
+
+export class IdentityVerificationError extends Error {
+  constructor(code) {
+    super(code);
+    this.name = "IdentityVerificationError";
+    this.code = code;
+  }
+}
+
+// Confirms "this caller is currently authenticated as some DID" without
+// this function ever holding a usable credential of its own. The browser's
+// OAuth session is DPoP-bound to a non-extractable, browser-generated key
+// (see src/js/oauth.js), so a bare access token is useless off-browser --
+// but a DPoP proof the browser already signed for one specific request is
+// safe to forward. We proxy exactly that one request (a GET to the caller's
+// own PDS's com.atproto.server.getSession) and trust the PDS's own
+// authoritative response.
+//
+// `verificationUrl` must be the exact URL the browser used as the DPoP
+// proof's `htu` claim (https, path ending in GET_SESSION_PATH) -- proxying
+// only that shape keeps this from being usable as an open HTTP proxy.
+export async function verifyIdentity({
+  verificationUrl,
+  accessToken,
+  dpopProof,
+}) {
+  if (!verificationUrl || !accessToken || !dpopProof) {
+    throw new IdentityVerificationError("missing_credentials");
+  }
+  let url;
+  try {
+    url = new URL(verificationUrl);
+  } catch {
+    throw new IdentityVerificationError("invalid_verification_url");
+  }
+  if (url.protocol !== "https:" || !url.pathname.endsWith(GET_SESSION_PATH)) {
+    throw new IdentityVerificationError("invalid_verification_url");
+  }
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `DPoP ${accessToken}`,
+      DPoP: dpopProof,
+    },
+  });
+
+  if (response.status === 400 || response.status === 401) {
+    let body = null;
+    try {
+      body = await response.json();
+    } catch {
+      // ignore
+    }
+    const nonce = response.headers.get("DPoP-Nonce");
+    if (body?.error === "use_dpop_nonce" && nonce) {
+      return { needsNonce: true, nonce };
+    }
+    throw new IdentityVerificationError("unauthorized");
+  }
+  if (!response.ok) {
+    throw new IdentityVerificationError("pds_error");
+  }
+
+  const data = await response.json();
+  if (!data?.did) {
+    throw new IdentityVerificationError("missing_did");
+  }
+  return { did: data.did };
+}

--- a/functions/_lib/kvKeys.js
+++ b/functions/_lib/kvKeys.js
@@ -1,0 +1,24 @@
+// KV key format for PUSH_SUBSCRIPTIONS, shared so subscribe/unsubscribe/relay
+// can't drift out of sync with each other.
+
+async function sha256Hex(value) {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function subscriptionKey(did, endpoint) {
+  return `sub:${did}:${await sha256Hex(endpoint)}`;
+}
+
+export function subscriptionPrefix(did) {
+  return `sub:${did}:`;
+}
+
+export function throttleKey(action, did) {
+  return `throttle:${action}:${did}`;
+}

--- a/functions/_lib/vapid.js
+++ b/functions/_lib/vapid.js
@@ -1,0 +1,46 @@
+import { base64UrlEncode, encodeUtf8 } from "./dpopVerify.js";
+
+// RFC 8292 recommends VAPID JWTs expire within 24h; keep well under that.
+const VAPID_JWT_LIFETIME_SECONDS = 12 * 60 * 60;
+
+async function importVapidPrivateKey(privateJwk) {
+  return crypto.subtle.importKey(
+    "jwk",
+    privateJwk,
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign"],
+  );
+}
+
+// Builds the `Authorization: vapid t=<jwt>, k=<publicKey>` header Web Push
+// services expect (RFC 8292). No payload/encryption involved -- pushes are
+// sent empty, so there's nothing here beyond identifying our server.
+export async function buildVapidAuthorizationHeader({
+  endpoint,
+  privateJwk,
+  publicKey,
+  subject,
+}) {
+  const origin = new URL(endpoint).origin;
+  const privateKey = await importVapidPrivateKey(privateJwk);
+  const now = Math.floor(Date.now() / 1000);
+  const header = { typ: "JWT", alg: "ES256" };
+  const payload = {
+    aud: origin,
+    exp: now + VAPID_JWT_LIFETIME_SECONDS,
+    sub: subject,
+  };
+
+  const headerB64 = base64UrlEncode(encodeUtf8(JSON.stringify(header)));
+  const payloadB64 = base64UrlEncode(encodeUtf8(JSON.stringify(payload)));
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const signature = await crypto.subtle.sign(
+    { name: "ECDSA", hash: "SHA-256" },
+    privateKey,
+    encodeUtf8(signingInput),
+  );
+  const jwt = `${signingInput}.${base64UrlEncode(signature)}`;
+
+  return `vapid t=${jwt}, k=${publicKey}`;
+}

--- a/functions/oauth/assertion.js
+++ b/functions/oauth/assertion.js
@@ -1,19 +1,8 @@
 // Signs OAuth client assertions (private_key_jwt)
 
+import { base64UrlEncode, encodeUtf8 } from "../_lib/dpopVerify.js";
+
 const ASSERTION_LIFETIME_SECONDS = 60;
-
-function base64UrlEncode(buffer) {
-  const bytes = new Uint8Array(buffer);
-  let binary = "";
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
-}
-
-function encodeUtf8(str) {
-  return new TextEncoder().encode(str);
-}
 
 function errorResponse(status, error) {
   return Response.json({ error }, { status });

--- a/functions/push/relay.js
+++ b/functions/push/relay.js
@@ -1,0 +1,105 @@
+import {
+  verifyIdentity,
+  IdentityVerificationError,
+} from "../_lib/dpopVerify.js";
+import { subscriptionPrefix, throttleKey } from "../_lib/kvKeys.js";
+import { buildVapidAuthorizationHeader } from "../_lib/vapid.js";
+
+const THROTTLE_TTL_SECONDS = 60; // KV enforces a 60s minimum expirationTtl
+const PUSH_TTL_SECONDS = 60 * 60 * 24; // 1 day, per RFC 8030 TTL header
+
+function errorResponse(status, error) {
+  return Response.json({ error }, { status });
+}
+
+export async function onRequestPost({ request, env }) {
+  if (!env.PUSH_SUBSCRIPTIONS) {
+    return errorResponse(501, "not_configured");
+  }
+  if (!env.VAPID_PRIVATE_JWK || !env.VAPID_PUBLIC_KEY || !env.VAPID_SUBJECT) {
+    return errorResponse(501, "not_configured");
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse(400, "invalid_request_body");
+  }
+  const { verificationUrl, accessToken, dpopProof, callerEndpoint } =
+    body ?? {};
+
+  let identity;
+  try {
+    identity = await verifyIdentity({
+      verificationUrl,
+      accessToken,
+      dpopProof,
+    });
+  } catch (error) {
+    if (error instanceof IdentityVerificationError) {
+      return errorResponse(401, error.code);
+    }
+    throw error;
+  }
+  if (identity.needsNonce) {
+    return Response.json(
+      { error: "use_dpop_nonce", nonce: identity.nonce },
+      { status: 428 },
+    );
+  }
+  const { did } = identity;
+
+  const throttle = throttleKey("relay", did);
+  if (await env.PUSH_SUBSCRIPTIONS.get(throttle)) {
+    return errorResponse(429, "rate_limited");
+  }
+  await env.PUSH_SUBSCRIPTIONS.put(throttle, "1", {
+    expirationTtl: THROTTLE_TTL_SECONDS,
+  });
+
+  const privateJwk = JSON.parse(env.VAPID_PRIVATE_JWK);
+  const list = await env.PUSH_SUBSCRIPTIONS.list({
+    prefix: subscriptionPrefix(did),
+  });
+
+  await Promise.all(
+    list.keys.map(async (key) => {
+      const raw = await env.PUSH_SUBSCRIPTIONS.get(key.name);
+      if (!raw) return;
+      let stored;
+      try {
+        stored = JSON.parse(raw);
+      } catch {
+        return;
+      }
+      const { subscription } = stored;
+      if (!subscription?.endpoint || subscription.endpoint === callerEndpoint) {
+        return;
+      }
+      try {
+        const authorization = await buildVapidAuthorizationHeader({
+          endpoint: subscription.endpoint,
+          privateJwk,
+          publicKey: env.VAPID_PUBLIC_KEY,
+          subject: env.VAPID_SUBJECT,
+        });
+        const pushResponse = await fetch(subscription.endpoint, {
+          method: "POST",
+          headers: {
+            Authorization: authorization,
+            TTL: String(PUSH_TTL_SECONDS),
+            "Content-Length": "0",
+          },
+        });
+        if (pushResponse.status === 404 || pushResponse.status === 410) {
+          await env.PUSH_SUBSCRIPTIONS.delete(key.name);
+        }
+      } catch (error) {
+        console.error("push relay failed for", key.name, error);
+      }
+    }),
+  );
+
+  return Response.json({ ok: true });
+}

--- a/functions/push/subscribe.js
+++ b/functions/push/subscribe.js
@@ -1,0 +1,69 @@
+import {
+  verifyIdentity,
+  IdentityVerificationError,
+} from "../_lib/dpopVerify.js";
+import { subscriptionKey, throttleKey } from "../_lib/kvKeys.js";
+
+// KV storage isn't request-fresh, so keep subscriptions well under
+// PushSubscription's own typical lifetime and let the client resubscribe.
+const SUBSCRIPTION_TTL_SECONDS = 60 * 60 * 24 * 60; // 60 days
+const THROTTLE_TTL_SECONDS = 60; // KV enforces a 60s minimum expirationTtl
+
+function errorResponse(status, error) {
+  return Response.json({ error }, { status });
+}
+
+export async function onRequestPost({ request, env }) {
+  if (!env.PUSH_SUBSCRIPTIONS) {
+    return errorResponse(501, "not_configured");
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse(400, "invalid_request_body");
+  }
+  const { verificationUrl, accessToken, dpopProof, subscription } = body ?? {};
+  if (!subscription?.endpoint || !subscription?.keys) {
+    return errorResponse(400, "invalid_subscription");
+  }
+
+  let identity;
+  try {
+    identity = await verifyIdentity({
+      verificationUrl,
+      accessToken,
+      dpopProof,
+    });
+  } catch (error) {
+    if (error instanceof IdentityVerificationError) {
+      return errorResponse(401, error.code);
+    }
+    throw error;
+  }
+  if (identity.needsNonce) {
+    return Response.json(
+      { error: "use_dpop_nonce", nonce: identity.nonce },
+      { status: 428 },
+    );
+  }
+  const { did } = identity;
+
+  const throttle = throttleKey("subscribe", did);
+  if (await env.PUSH_SUBSCRIPTIONS.get(throttle)) {
+    return errorResponse(429, "rate_limited");
+  }
+  await env.PUSH_SUBSCRIPTIONS.put(throttle, "1", {
+    expirationTtl: THROTTLE_TTL_SECONDS,
+  });
+
+  const key = await subscriptionKey(did, subscription.endpoint);
+  await env.PUSH_SUBSCRIPTIONS.put(
+    key,
+    JSON.stringify({ subscription, createdAt: Date.now() }),
+    { expirationTtl: SUBSCRIPTION_TTL_SECONDS },
+  );
+
+  return Response.json({ ok: true });
+}

--- a/functions/push/unsubscribe.js
+++ b/functions/push/unsubscribe.js
@@ -1,0 +1,51 @@
+import {
+  verifyIdentity,
+  IdentityVerificationError,
+} from "../_lib/dpopVerify.js";
+import { subscriptionKey } from "../_lib/kvKeys.js";
+
+function errorResponse(status, error) {
+  return Response.json({ error }, { status });
+}
+
+export async function onRequestPost({ request, env }) {
+  if (!env.PUSH_SUBSCRIPTIONS) {
+    return errorResponse(501, "not_configured");
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse(400, "invalid_request_body");
+  }
+  const { verificationUrl, accessToken, dpopProof, endpoint } = body ?? {};
+  if (!endpoint) {
+    return errorResponse(400, "missing_endpoint");
+  }
+
+  let identity;
+  try {
+    identity = await verifyIdentity({
+      verificationUrl,
+      accessToken,
+      dpopProof,
+    });
+  } catch (error) {
+    if (error instanceof IdentityVerificationError) {
+      return errorResponse(401, error.code);
+    }
+    throw error;
+  }
+  if (identity.needsNonce) {
+    return Response.json(
+      { error: "use_dpop_nonce", nonce: identity.nonce },
+      { status: 428 },
+    );
+  }
+
+  const key = await subscriptionKey(identity.did, endpoint);
+  await env.PUSH_SUBSCRIPTIONS.delete(key);
+
+  return Response.json({ ok: true });
+}

--- a/functions/push/vapid-public-key.js
+++ b/functions/push/vapid-public-key.js
@@ -1,0 +1,10 @@
+// Trivial capability probe: the client uses this to decide whether to show
+// the cross-device relay toggle at all, without needing to know in advance
+// whether this deployment has Tier 2 configured.
+
+export async function onRequestGet({ env }) {
+  if (!env.PUSH_SUBSCRIPTIONS || !env.VAPID_PUBLIC_KEY) {
+    return Response.json({ error: "not_configured" }, { status: 501 });
+  }
+  return Response.json({ key: env.VAPID_PUBLIC_KEY });
+}

--- a/scripts/generate-vapid-keypair.js
+++ b/scripts/generate-vapid-keypair.js
@@ -1,0 +1,28 @@
+const { publicKey, privateKey } = await crypto.subtle.generateKey(
+  { name: "ECDSA", namedCurve: "P-256" },
+  true,
+  ["sign", "verify"],
+);
+
+function base64UrlEncode(buffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+const publicKeyRaw = await crypto.subtle.exportKey("raw", publicKey);
+const privateJwk = await crypto.subtle.exportKey("jwk", privateKey);
+
+console.log("VAPID_PUBLIC_KEY (build variable):");
+console.log(base64UrlEncode(publicKeyRaw));
+console.log("");
+console.log("VAPID_PRIVATE_JWK (secret — do not commit):");
+console.log(JSON.stringify(privateJwk));
+console.log("");
+console.log(
+  "VAPID_SUBJECT (build variable — a mailto: or https: contact, required by RFC 8292):",
+);
+console.log("mailto:you@example.com");

--- a/src/_routes.json
+++ b/src/_routes.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "include": ["/js/*", "/css/*", "/img/*", "/oauth/*"],
+  "include": ["/js/*", "/css/*", "/img/*", "/oauth/*", "/push/*"],
   "exclude": []
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -45,6 +45,7 @@ import { auth } from "/js/auth.js";
 import { NotificationService } from "/js/notificationService.js";
 import { ChatNotificationService } from "/js/chatNotificationService.js";
 import { SystemNotificationService } from "/js/systemNotificationService.js";
+import { PushSubscriptionService } from "/js/push/pushSubscriptionService.js";
 import { PostComposerService } from "/js/postComposerService.js";
 import { AccountSwitcherService } from "/js/accountSwitcherService.js";
 import { ReportService } from "/js/reportService.js";
@@ -123,12 +124,16 @@ export async function main() {
   const chatNotificationService = session
     ? new ChatNotificationService(api)
     : null;
+  const pushSubscriptionService = session
+    ? new PushSubscriptionService(session)
+    : null;
   const systemNotificationService =
     notificationService && chatNotificationService
       ? new SystemNotificationService(
           notificationService,
           chatNotificationService,
           router,
+          pushSubscriptionService,
         )
       : null;
   const postComposerService = session
@@ -209,6 +214,7 @@ export async function main() {
     notificationService,
     chatNotificationService,
     systemNotificationService,
+    pushSubscriptionService,
     postComposerService,
     accountSwitcherService,
     reportService,

--- a/src/js/chatNotificationService.js
+++ b/src/js/chatNotificationService.js
@@ -12,10 +12,16 @@ export class ChatNotificationService {
     this._lastServerTotal = 0;
   }
 
-  async startPolling() {
+  async startPolling(signal) {
     const pollingInterval = POLLING_INTERVAL_SECONDS * 1000;
-    while (true) {
-      await this.fetchNumNotifications();
+    while (!signal?.aborted) {
+      try {
+        await this.fetchNumNotifications();
+      } catch (error) {
+        // A single failed poll (network blip, auth hiccup) shouldn't kill
+        // polling for the rest of the session -- just try again next tick.
+        console.error(error);
+      }
       await wait(pollingInterval);
     }
   }

--- a/src/js/notificationService.js
+++ b/src/js/notificationService.js
@@ -26,11 +26,17 @@ export class NotificationService {
     return snoozedUntil ? new Date(snoozedUntil) > new Date() : false;
   }
 
-  async startPolling() {
+  async startPolling(signal) {
     const pollingInterval = POLLING_INTERVAL_SECONDS * 1000;
-    while (true) {
-      if (!this.isSnoozed) {
-        await this.fetchNumNotifications();
+    while (!signal?.aborted) {
+      try {
+        if (!this.isSnoozed) {
+          await this.fetchNumNotifications();
+        }
+      } catch (error) {
+        // A single failed poll (network blip, auth hiccup) shouldn't kill
+        // polling for the rest of the session -- just try again next tick.
+        console.error(error);
       }
       await wait(pollingInterval);
     }

--- a/src/js/oauth.js
+++ b/src/js/oauth.js
@@ -489,6 +489,34 @@ export class Session {
     return this.sessionData.serviceEndpoint;
   }
 
+  // Builds a DPoP-proofed `{ accessToken, dpopProof }` pair for a specific
+  // method/url, without actually performing the request. Used to let a
+  // server we don't otherwise trust (e.g. the push-notification relay
+  // function) proxy a single, narrowly-scoped call to our own PDS as proof
+  // of current identity, without ever handing it a usable credential of its
+  // own. Pass `nonce` to retry after a server-reported `use_dpop_nonce`.
+  async buildDpopProof(method, url, { nonce = null } = {}) {
+    if (Date.now() > this.sessionData.expiresAt - 60000) {
+      if (!this.pendingRefresh) {
+        this.pendingRefresh = this.refreshToken().finally(() => {
+          this.pendingRefresh = null;
+        });
+      }
+      await this.pendingRefresh;
+    }
+    const accessToken = this.sessionData.accessToken;
+    const origin = new URL(url).origin;
+    const effectiveNonce =
+      nonce ?? this.dpopRequests.nonces.get(origin) ?? null;
+    const dpopProof = await this.dpopRequests.createProof(
+      method,
+      url,
+      effectiveNonce,
+      accessToken,
+    );
+    return { accessToken, dpopProof };
+  }
+
   get scope() {
     return this.sessionData.scope ?? null;
   }

--- a/src/js/push/pushSubscriptionService.js
+++ b/src/js/push/pushSubscriptionService.js
@@ -1,0 +1,140 @@
+import { isNative } from "/js/utils.js";
+
+const SW_URL = "/sw.js";
+const RELAY_STORAGE_KEY = "system-notifications-relay-enabled";
+const GET_SESSION_PATH = "/xrpc/com.atproto.server.getSession";
+
+function base64UrlToUint8Array(base64Url) {
+  const padding = "=".repeat((4 - (base64Url.length % 4)) % 4);
+  const base64 = (base64Url + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(base64);
+  const output = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) {
+    output[i] = raw.charCodeAt(i);
+  }
+  return output;
+}
+
+// Cross-device relay (Tier 2): a device with Impro open relays a real push
+// to the user's other, possibly fully-closed devices. The server never
+// holds a login credential -- each request proves current identity by
+// having the browser generate a DPoP proof for a call to its own PDS's
+// getSession, which our function proxies through and trusts (see
+// functions/_lib/dpopVerify.js and Session.buildDpopProof in oauth.js).
+export class PushSubscriptionService {
+  constructor(session) {
+    this.session = session;
+  }
+
+  get isSupported() {
+    return (
+      !isNative() &&
+      typeof navigator !== "undefined" &&
+      "serviceWorker" in navigator &&
+      typeof window !== "undefined" &&
+      "PushManager" in window &&
+      typeof this.session?.buildDpopProof === "function"
+    );
+  }
+
+  get isEnabled() {
+    return localStorage.getItem(RELAY_STORAGE_KEY) === "true";
+  }
+
+  // Returns the deployment's VAPID public key, or null if this deployment
+  // hasn't configured Tier 2 (or the browser can't support it) -- the
+  // settings UI uses this to decide whether to show the relay toggle.
+  async probeAvailability() {
+    if (!this.isSupported) return null;
+    try {
+      const response = await fetch("/push/vapid-public-key");
+      if (!response.ok) return null;
+      const { key } = await response.json();
+      return key ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  async _verificationCredentials(nonce = null) {
+    const verificationUrl = `${this.session.serviceEndpoint}${GET_SESSION_PATH}`;
+    const { accessToken, dpopProof } = await this.session.buildDpopProof(
+      "GET",
+      verificationUrl,
+      { nonce },
+    );
+    return { verificationUrl, accessToken, dpopProof };
+  }
+
+  async _postWithNonceRetry(url, extraBody) {
+    const post = async (nonce) => {
+      const credentials = await this._verificationCredentials(nonce);
+      return fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...credentials, ...extraBody }),
+      });
+    };
+    let response = await post(null);
+    if (response.status === 428) {
+      const { nonce } = await response.json();
+      response = await post(nonce);
+    }
+    return response;
+  }
+
+  async subscribe(vapidPublicKey) {
+    if (!this.isSupported) return false;
+    await navigator.serviceWorker.register(SW_URL);
+    const registration = await navigator.serviceWorker.ready;
+    const subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: base64UrlToUint8Array(vapidPublicKey),
+    });
+    let response;
+    try {
+      response = await this._postWithNonceRetry("/push/subscribe", {
+        subscription: subscription.toJSON(),
+      });
+    } catch (error) {
+      await subscription.unsubscribe().catch(() => {});
+      throw error;
+    }
+    if (!response.ok) {
+      await subscription.unsubscribe().catch(() => {});
+      return false;
+    }
+    localStorage.setItem(RELAY_STORAGE_KEY, "true");
+    return true;
+  }
+
+  async unsubscribe() {
+    localStorage.removeItem(RELAY_STORAGE_KEY);
+    if (!this.isSupported) return;
+    const registration = await navigator.serviceWorker.getRegistration(SW_URL);
+    const subscription = await registration?.pushManager.getSubscription();
+    if (!subscription) return;
+    const endpoint = subscription.endpoint;
+    await subscription.unsubscribe().catch(() => {});
+    try {
+      await this._postWithNonceRetry("/push/unsubscribe", { endpoint });
+    } catch (error) {
+      console.warn("push unsubscribe failed", error);
+    }
+  }
+
+  async relay() {
+    if (!this.isEnabled || !this.isSupported) return;
+    try {
+      const registration =
+        await navigator.serviceWorker.getRegistration(SW_URL);
+      const subscription = await registration?.pushManager.getSubscription();
+      if (!subscription) return;
+      await this._postWithNonceRetry("/push/relay", {
+        callerEndpoint: subscription.endpoint,
+      });
+    } catch (error) {
+      console.warn("push relay failed", error);
+    }
+  }
+}

--- a/src/js/signals.js
+++ b/src/js/signals.js
@@ -116,7 +116,13 @@ export const effect = (cb, { debugName, debugDepth } = {}) => {
   const run = () => {
     const prevRunTick = lastRunTick;
     ranThisFlush = false;
-    computed.get();
+    try {
+      computed.get();
+    } finally {
+      // Re-arm even if the callback threw -- otherwise one uncaught error
+      // permanently stops this effect from ever reacting again.
+      watcher.watch();
+    }
     if (ranThisFlush) {
       if (hasRun && debugName) {
         logEffectTrigger(computed, debugName, debugDepth, prevRunTick);
@@ -124,7 +130,6 @@ export const effect = (cb, { debugName, debugDepth } = {}) => {
       lastRunTick = globalTick;
       hasRun = true;
     }
-    watcher.watch(); // re-arm
   };
 
   const watcher = new PolyfillSignal.subtle.Watcher(() => {

--- a/src/js/systemNotificationService.js
+++ b/src/js/systemNotificationService.js
@@ -2,6 +2,7 @@ import { effect } from "/js/signals.js";
 
 const STORAGE_KEY = "system-notifications-enabled";
 const ICON_URL = "/img/impro-logo-192.png";
+const SW_URL = "/sw.js";
 
 export class SystemNotificationService {
   constructor(
@@ -73,6 +74,9 @@ export class SystemNotificationService {
     const result = await Notification.requestPermission();
     if (result === "granted") {
       localStorage.setItem(STORAGE_KEY, "true");
+      // Pre-warm the service worker so it's already active by the time a
+      // notification actually needs to be shown.
+      this._getServiceWorkerRegistration();
     }
     return result;
   }
@@ -81,7 +85,26 @@ export class SystemNotificationService {
     localStorage.removeItem(STORAGE_KEY);
   }
 
-  notify({ title, body, tag, url }) {
+  // Chrome on Android (and most other mobile browsers) throw when calling
+  // `new Notification()` directly from page context -- they only support
+  // notifications shown via a service worker's registration. Desktop
+  // browsers support both, so route through the service worker everywhere
+  // it's available and only fall back to the page-context constructor when
+  // it isn't.
+  async _getServiceWorkerRegistration() {
+    if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) {
+      return null;
+    }
+    try {
+      await navigator.serviceWorker.register(SW_URL);
+      return await navigator.serviceWorker.ready;
+    } catch (error) {
+      console.error(error);
+      return null;
+    }
+  }
+
+  async notify({ title, body, tag, url }) {
     if (
       !this.isSupported ||
       !this.isEnabled ||
@@ -90,17 +113,26 @@ export class SystemNotificationService {
     ) {
       return;
     }
-    const notification = new Notification(title, {
+    const options = {
       body,
       icon: ICON_URL,
       badge: ICON_URL,
       tag,
-    });
-    notification.onclick = () => {
-      window.focus();
-      this.router.go(url);
-      notification.close();
+      data: { url },
     };
+
+    const registration = await this._getServiceWorkerRegistration();
+    if (registration) {
+      await registration.showNotification(title, options);
+    } else {
+      const notification = new Notification(title, options);
+      notification.onclick = () => {
+        window.focus();
+        this.router.go(url);
+        notification.close();
+      };
+    }
+
     if (this.pushSubscriptionService?.isEnabled) {
       this.pushSubscriptionService.relay();
     }

--- a/src/js/systemNotificationService.js
+++ b/src/js/systemNotificationService.js
@@ -4,10 +4,16 @@ const STORAGE_KEY = "system-notifications-enabled";
 const ICON_URL = "/img/impro-logo-192.png";
 
 export class SystemNotificationService {
-  constructor(notificationService, chatNotificationService, router) {
+  constructor(
+    notificationService,
+    chatNotificationService,
+    router,
+    pushSubscriptionService = null,
+  ) {
     this.notificationService = notificationService;
     this.chatNotificationService = chatNotificationService;
     this.router = router;
+    this.pushSubscriptionService = pushSubscriptionService;
     this._lastSeenActivityCount =
       notificationService.$numNotifications.get() ?? 0;
     this._lastSeenChatCount =
@@ -95,5 +101,8 @@ export class SystemNotificationService {
       this.router.go(url);
       notification.close();
     };
+    if (this.pushSubscriptionService?.isEnabled) {
+      this.pushSubscriptionService.relay();
+    }
   }
 }

--- a/src/js/views/settings/notifications.view.js
+++ b/src/js/views/settings/notifications.view.js
@@ -13,13 +13,26 @@ class SettingsNotificationsView extends View {
     root,
     router,
     layout,
-    context: { systemNotificationService },
+    context: { systemNotificationService, pushSubscriptionService },
   }) {
     await auth.requireAuth();
 
     const $enabled = new Signal.State(
       systemNotificationService?.isEnabled ?? false,
     );
+    const $relayEnabled = new Signal.State(
+      pushSubscriptionService?.isEnabled ?? false,
+    );
+    const $relayPending = new Signal.State(false);
+    // null until the capability probe resolves; stays null forever on
+    // deployments that haven't configured Tier 2, which hides the toggle.
+    const $vapidKey = new Signal.State(null);
+
+    if (pushSubscriptionService) {
+      pushSubscriptionService.probeAvailability().then((key) => {
+        $vapidKey.set(key);
+      });
+    }
 
     async function handleToggle(checked) {
       if (!systemNotificationService) return;
@@ -47,6 +60,35 @@ class SettingsNotificationsView extends View {
       }
     }
 
+    async function handleRelayToggle(checked) {
+      if (!pushSubscriptionService || $relayPending.get()) return;
+      $relayPending.set(true);
+      try {
+        if (!checked) {
+          await pushSubscriptionService.unsubscribe();
+          $relayEnabled.set(false);
+          return;
+        }
+        const vapidPublicKey = $vapidKey.get();
+        if (!vapidPublicKey) return;
+        const ok = await pushSubscriptionService.subscribe(vapidPublicKey);
+        $relayEnabled.set(ok);
+        if (!ok) {
+          showToast("Couldn't enable notifications on your other devices.", {
+            style: "error",
+          });
+        }
+      } catch (error) {
+        console.error(error);
+        $relayEnabled.set(false);
+        showToast("Couldn't enable notifications on your other devices.", {
+          style: "error",
+        });
+      } finally {
+        $relayPending.set(false);
+      }
+    }
+
     bindToPage(root, layout, "active-nav-click", (event) => {
       event.preventDefault();
       router.go("/settings");
@@ -69,6 +111,10 @@ class SettingsNotificationsView extends View {
         description =
           "Notifications are blocked for this site. Re-enable them in your browser's site settings to turn this on.";
       }
+
+      const vapidKey = $vapidKey.get();
+      const relayEnabled = $relayEnabled.get();
+      const relayPending = $relayPending.get();
 
       render(
         html`<div id="settings-notifications-view">
@@ -95,6 +141,31 @@ class SettingsNotificationsView extends View {
                 ></toggle-switch>
               </div>
             </section>
+            ${vapidKey
+              ? html`<section
+                  class="setting-item"
+                  data-testid="settings-section-relay-notifications"
+                >
+                  <div class="setting-item-info">
+                    <h2 class="setting-item-name">Notify my other devices</h2>
+                    <p class="setting-item-desc">
+                      ${enabled
+                        ? "When this device sees new activity, also send a notification to your other signed-in devices, even if they're closed."
+                        : "Enable system notifications above first."}
+                    </p>
+                  </div>
+                  <div class="setting-item-control">
+                    <toggle-switch
+                      data-testid="relay-notifications-toggle"
+                      label="Notify my other devices"
+                      ?checked=${relayEnabled}
+                      ?disabled=${!enabled || relayPending}
+                      @change=${(event) =>
+                        handleRelayToggle(event.detail.checked)}
+                    ></toggle-switch>
+                  </div>
+                </section>`
+              : null}
           </main>
         </div>`,
         root,

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,0 +1,37 @@
+// Service worker for Web Push notifications (Tier 2 / cross-device relay).
+// Push messages are sent with no payload (see functions/push/relay.js), so
+// there's nothing to decrypt here — just show a generic notification.
+
+const NOTIFICATION_ICON = "/img/impro-logo-192.png";
+
+self.addEventListener("push", (event) => {
+  event.waitUntil(
+    self.registration.showNotification("New activity on Impro", {
+      body: "You have new activity on one of your other devices.",
+      icon: NOTIFICATION_ICON,
+      badge: NOTIFICATION_ICON,
+      tag: "impro-push",
+      data: { url: "/notifications" },
+    }),
+  );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const url = event.notification.data?.url ?? "/";
+  event.waitUntil(
+    (async () => {
+      const clientsList = await clients.matchAll({
+        type: "window",
+        includeUncontrolled: true,
+      });
+      for (const client of clientsList) {
+        if (!("focus" in client)) continue;
+        await client.focus();
+        if ("navigate" in client) await client.navigate(url);
+        return;
+      }
+      await clients.openWindow(url);
+    })(),
+  );
+});

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,4 +1,7 @@
-// Service worker for Web Push notifications (Tier 2 / cross-device relay).
+// Service worker backing system notifications. `notificationclick` handles
+// clicks for both Tier 1 (SystemNotificationService.notify(), shown via this
+// registration since raw `new Notification()` doesn't work on Android) and
+// Tier 2 (Web Push cross-device relay, handled by the `push` listener below).
 // Push messages are sent with no payload (see functions/push/relay.js), so
 // there's nothing to decrypt here — just show a generic notification.
 

--- a/tests/unit/specs/chatNotificationService.test.js
+++ b/tests/unit/specs/chatNotificationService.test.js
@@ -96,6 +96,38 @@ describe("fetchNumNotifications", () => {
   });
 });
 
+describe("startPolling", () => {
+  it("keeps polling after a poll throws", async () => {
+    let calls = 0;
+    const api = {
+      getChatUnreadCounts: async () => {
+        calls++;
+        if (calls === 1) throw new Error("network blip");
+        return { unreadAcceptedConvos: 3, unreadRequestConvos: 0 };
+      },
+    };
+    const service = new ChatNotificationService(api);
+    const originalError = console.error;
+    console.error = () => {};
+    const originalSetTimeout = globalThis.setTimeout;
+    globalThis.setTimeout = (fn) => originalSetTimeout(fn, 0);
+
+    const controller = new AbortController();
+    const pollingPromise = service.startPolling(controller.signal);
+    try {
+      while (calls < 2) {
+        await new Promise((resolve) => originalSetTimeout(resolve, 0));
+      }
+      assert.deepEqual(service.$numNotifications.get(), 3);
+    } finally {
+      controller.abort();
+      await pollingPromise;
+      console.error = originalError;
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+});
+
 describe("markNotificationsAsReadForConvo", () => {
   it("should optimistically decrement the count", async () => {
     const api = createMockApi({ unreadAcceptedConvos: 3 });

--- a/tests/unit/specs/notificationService.test.js
+++ b/tests/unit/specs/notificationService.test.js
@@ -178,6 +178,34 @@ describe("NotificationService", () => {
     });
   });
 
+  describe("startPolling", () => {
+    it("keeps polling after a poll throws", async () => {
+      let calls = 0;
+      const api = createMockApi();
+      api.getNumNotifications = async () => {
+        calls++;
+        if (calls === 1) throw new Error("network blip");
+        return 3;
+      };
+      const service = new NotificationService(api);
+      const originalError = console.error;
+      console.error = () => {};
+
+      const controller = new AbortController();
+      const pollingPromise = service.startPolling(controller.signal);
+      try {
+        while (calls < 2) {
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+        assert.deepEqual(service.$numNotifications.get(), 3);
+      } finally {
+        controller.abort();
+        await pollingPromise;
+        console.error = originalError;
+      }
+    });
+  });
+
   describe("$numNotifications", () => {
     it("should reflect current notification count", async () => {
       const api = createMockApi({ numNotifications: 7 });

--- a/tests/unit/specs/signals.test.js
+++ b/tests/unit/specs/signals.test.js
@@ -1,6 +1,20 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { Signal, SignalSet, SignalMap, SignalArray } from "/js/signals.js";
+import {
+  Signal,
+  SignalSet,
+  SignalMap,
+  SignalArray,
+  effect,
+} from "/js/signals.js";
+
+// effect() batches reactions via a double requestAnimationFrame (see
+// signals.js) - this waits for that flush to actually happen.
+function flushEffects() {
+  return new Promise((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(resolve)),
+  );
+}
 
 describe("SignalSet - Set behavior", () => {
   it("starts empty by default", () => {
@@ -511,5 +525,87 @@ describe("SignalArray - reactivity", () => {
     arr.replace(["a", "b"]);
     assert.deepEqual($length.get(), 2);
     assert.deepEqual(runs, 2);
+  });
+});
+
+describe("effect", () => {
+  it("re-runs when a read signal changes", async () => {
+    const $count = new Signal.State(0);
+    const seen = [];
+    const dispose = effect(() => {
+      seen.push($count.get());
+    });
+    try {
+      $count.set(1);
+      await flushEffects();
+      assert.deepEqual(seen, [0, 1]);
+    } finally {
+      dispose();
+    }
+  });
+
+  it("keeps reacting to future changes even after the callback throws", () => {
+    // effect() schedules its reaction inside a requestAnimationFrame
+    // callback. An exception thrown there is a genuinely uncaught
+    // exception (same as in a real browser) - not something a surrounding
+    // try/catch or .catch() can observe, and node:test fails the test for
+    // any uncaught exception during its run regardless of handlers.
+    //
+    // Auto-running rAF synchronously doesn't work either: it would fire
+    // while still inside the signal's own change-notification dispatch
+    // (reentrantly), which trips the signal library's own reentrancy guard
+    // instead of exercising our code at all. Instead, capture the pending
+    // rAF callback and invoke it manually, after set() has already
+    // returned -- that's a plain synchronous call in our own test code, so
+    // a normal try/catch works and nothing is ever actually "uncaught".
+    const originalRaf = globalThis.requestAnimationFrame;
+    let pendingRaf = null;
+    globalThis.requestAnimationFrame = (cb) => {
+      pendingRaf = cb;
+    };
+    try {
+      const $count = new Signal.State(0);
+      const seen = [];
+      const dispose = effect(() => {
+        const value = $count.get();
+        seen.push(value);
+        if (value === 1) {
+          throw new Error("boom");
+        }
+      });
+      try {
+        $count.set(1);
+        assert.ok(pendingRaf, "expected a reaction to be scheduled");
+        assert.throws(() => pendingRaf(), /boom/);
+
+        // The regression this guards against: a naive implementation stops
+        // re-arming its watcher once the callback throws, so this second
+        // change would silently never be observed.
+        pendingRaf = null;
+        $count.set(2);
+        assert.ok(pendingRaf, "expected the effect to still be re-armed");
+        pendingRaf();
+
+        assert.deepEqual(seen, [0, 1, 2]);
+      } finally {
+        dispose();
+      }
+    } finally {
+      globalThis.requestAnimationFrame = originalRaf;
+    }
+  });
+
+  it("stops reacting after dispose", async () => {
+    const $count = new Signal.State(0);
+    const seen = [];
+    const dispose = effect(() => {
+      seen.push($count.get());
+    });
+    dispose();
+
+    $count.set(1);
+    await flushEffects();
+
+    assert.deepEqual(seen, [0]);
   });
 });

--- a/tests/unit/specs/systemNotificationService.test.js
+++ b/tests/unit/specs/systemNotificationService.test.js
@@ -206,6 +206,87 @@ describe("SystemNotificationService", () => {
     });
   });
 
+  describe("service worker delivery", () => {
+    let hadServiceWorker;
+    let originalServiceWorker;
+    let swInstances;
+    let registration;
+
+    beforeEach(() => {
+      swInstances = [];
+      registration = {
+        showNotification: (title, options) => {
+          swInstances.push({ title, options });
+        },
+      };
+      hadServiceWorker = "serviceWorker" in navigator;
+      originalServiceWorker = navigator.serviceWorker;
+      Object.defineProperty(navigator, "serviceWorker", {
+        configurable: true,
+        value: {
+          register: async () => registration,
+          ready: Promise.resolve(registration),
+        },
+      });
+    });
+
+    afterEach(() => {
+      if (hadServiceWorker) {
+        Object.defineProperty(navigator, "serviceWorker", {
+          configurable: true,
+          value: originalServiceWorker,
+        });
+      } else {
+        delete navigator.serviceWorker;
+      }
+    });
+
+    it("shows notifications via the service worker instead of the raw constructor", async () => {
+      const notificationService = createMockNotificationService();
+      const chatNotificationService = createMockChatNotificationService();
+      enable();
+      startService(notificationService, chatNotificationService);
+
+      notificationService.$numNotifications.set(3);
+      await flushEffects();
+
+      assert.deepEqual(
+        instances.length,
+        0,
+        "should not fall back to `new Notification()`",
+      );
+      assert.deepEqual(swInstances.length, 1);
+      assert.deepEqual(swInstances[0].title, "New activity on Impro");
+      assert.deepEqual(swInstances[0].options.data, { url: "/notifications" });
+      assert.deepEqual(swInstances[0].options.tag, "impro-activity");
+    });
+
+    it("falls back to the raw constructor if service worker registration fails", async () => {
+      Object.defineProperty(navigator, "serviceWorker", {
+        configurable: true,
+        value: {
+          register: async () => {
+            throw new Error("registration failed");
+          },
+          ready: Promise.resolve(registration),
+        },
+      });
+      const notificationService = createMockNotificationService();
+      const chatNotificationService = createMockChatNotificationService();
+      const originalError = console.error;
+      console.error = () => {};
+      enable();
+      startService(notificationService, chatNotificationService);
+
+      notificationService.$numNotifications.set(3);
+      await flushEffects();
+
+      console.error = originalError;
+      assert.deepEqual(swInstances.length, 0);
+      assert.deepEqual(instances.length, 1);
+    });
+  });
+
   describe("cross-device relay", () => {
     it("relays to other devices when the relay toggle is enabled", async () => {
       const notificationService = createMockNotificationService();

--- a/tests/unit/specs/systemNotificationService.test.js
+++ b/tests/unit/specs/systemNotificationService.test.js
@@ -36,11 +36,16 @@ describe("SystemNotificationService", () => {
   let navigations;
   let router;
 
-  function startService(notificationService, chatNotificationService) {
+  function startService(
+    notificationService,
+    chatNotificationService,
+    pushSubscriptionService,
+  ) {
     const service = new SystemNotificationService(
       notificationService,
       chatNotificationService,
       router,
+      pushSubscriptionService,
     );
     const dispose = service.start();
     disposers.push(dispose);
@@ -198,6 +203,63 @@ describe("SystemNotificationService", () => {
       await flushEffects();
       instances[1].onclick();
       assert.deepEqual(navigations, ["/notifications", "/messages"]);
+    });
+  });
+
+  describe("cross-device relay", () => {
+    it("relays to other devices when the relay toggle is enabled", async () => {
+      const notificationService = createMockNotificationService();
+      const chatNotificationService = createMockChatNotificationService();
+      const relayCalls = [];
+      const pushSubscriptionService = {
+        isEnabled: true,
+        relay: () => relayCalls.push(true),
+      };
+      enable();
+      startService(
+        notificationService,
+        chatNotificationService,
+        pushSubscriptionService,
+      );
+
+      notificationService.$numNotifications.set(3);
+      await flushEffects();
+
+      assert.deepEqual(relayCalls.length, 1);
+    });
+
+    it("does not relay when the relay toggle is disabled", async () => {
+      const notificationService = createMockNotificationService();
+      const chatNotificationService = createMockChatNotificationService();
+      const relayCalls = [];
+      const pushSubscriptionService = {
+        isEnabled: false,
+        relay: () => relayCalls.push(true),
+      };
+      enable();
+      startService(
+        notificationService,
+        chatNotificationService,
+        pushSubscriptionService,
+      );
+
+      notificationService.$numNotifications.set(3);
+      await flushEffects();
+
+      assert.deepEqual(relayCalls.length, 0);
+    });
+
+    it("does not relay when there is no push subscription service", async () => {
+      const notificationService = createMockNotificationService();
+      const chatNotificationService = createMockChatNotificationService();
+      enable();
+      startService(notificationService, chatNotificationService, null);
+
+      notificationService.$numNotifications.set(3);
+      await flushEffects();
+
+      // No assertion needed beyond "doesn't throw" -- pushSubscriptionService
+      // is optional and notify() must tolerate it being absent.
     });
   });
 


### PR DESCRIPTION
## Stacked on #31 and #32 — review those first

`notifications-open-tab` (#29) has since merged, so this branch is rebased directly on `main`. It's currently stacked on **#31** (the `effect()` recovery fix) and **#32** (the notification/chat badge polling recovery fix) — both independently useful bugfixes this branch also benefits from, since they fix two separate cases of a signal/polling loop silently dying forever after a single uncaught exception, one in the reactive `effect()` utility and one in the badge polling loops. Until both merge, this PR's commit list includes their commits too — the commits actually new here are **"Add cross-device push notification relay"** and **"Route Tier 1 notifications through the service worker for Android support"** (see below). Once #31 and #32 merge to `main`, this PR's diff will automatically shrink to just those two.

## Also fixes: Tier 1 notifications never worked on Android

While dogfooding this on a live test deployment, found that Tier 1 (#29, already merged to `main`) has never been able to show a notification on Chrome for Android at all — tab or installed PWA. `SystemNotificationService.notify()` calls `new Notification(...)` directly from page context, which Android throws on; mobile browsers there only support notifications shown via a service worker's registration (`ServiceWorkerRegistration.showNotification()`). This is unchanged on `main` right now, not a regression from anything in this stack.

It has to be fixed here rather than as its own standalone PR: the fix routes `notify()` through a service worker registration, and `sw.js` doesn't exist on `main` yet — it's introduced by this PR for Tier 2. So this branch's service worker now backs both tiers: `sw.js`'s existing `notificationclick` listener already reads `notification.data.url` generically, so Tier 1's click handling moves there too, for free, with no changes needed beyond passing the same `data: { url }` shape Tier 2 already uses. Falls back to the raw constructor if a service worker isn't available for some reason.

## Summary

When one signed-in device detects something new via its own open-tab polling (from #29), it can relay a real push to your *other* devices, even if those are fully closed. Adds a service worker, Web Push (VAPID) subscriptions, and Cloudflare Pages Functions (`functions/push/*`) backed by Workers KV.

Server-side polling on the user's behalf was evaluated and ruled out: OAuth sessions here are DPoP-bound to a non-extractable, browser-generated key, so a captured refresh token is useless off-browser. Rather than working around that (which would mean the server holding a live, continuously-refreshed session per opted-in user — a real trust expansion), the relay's identity check instead has the browser generate a single, narrowly-scoped DPoP proof for a call to its own PDS's `com.atproto.server.getSession`, which the Cloudflare Function proxies through and trusts (`functions/_lib/dpopVerify.js`). The server never sees or stores a usable credential — it's a dumb relay + subscription store.

Push messages are sent payload-less (no `web-push`/aes128gcm dependency needed) — the service worker shows a generic notification and the client already has the real detail from its own polling.

Gracefully degrades to just open-tab notifications if a deployment hasn't configured the KV binding/VAPID secrets: `functions/push/vapid-public-key.js` is a capability probe the client checks before showing the "Notify my other devices" toggle at all, and every `/push/*` function returns a clean `501` if unconfigured (same pattern `functions/oauth/assertion.js` already uses for `OAUTH_PRIVATE_JWK` — now factored into `functions/_lib/` so both share the same Web Crypto JWT-signing helpers).

## What needs to be enabled on the Cloudflare side

Nothing is required to just merge this — every `/push/*` function no-ops with a `501` until a deployment configures it. Per deployment that wants it live:

- A **Workers KV namespace** bound as `PUSH_SUBSCRIPTIONS` on the Pages project.
- Three project vars/secrets: `VAPID_PUBLIC_KEY` and `VAPID_SUBJECT` (plain vars) and `VAPID_PRIVATE_JWK` (secret). Generate a keypair with `node scripts/generate-vapid-keypair.js`.
- `/push/*` is already added to `src/_routes.json`'s `include` list in this PR — without that, Cloudflare Pages never invokes these functions at all, regardless of the above.

None of this needs a `wrangler.toml` committed to the repo — it's deployment-specific (KV namespace IDs, public key), so it's gitignored; generate your own.

### How I set this up via CLI, with a Cloudflare API token

```sh
# Token: Account -> Cloudflare Pages -> Edit, Account -> Workers KV Storage -> Edit.
# (If you also want to script a custom-domain attachment: Zone -> DNS -> Edit,
# in its OWN policy -- Cloudflare tokens silently drop one side if you mix
# account- and zone-scoped resources into a single policy.)
export CLOUDFLARE_API_TOKEN=...
export CLOUDFLARE_ACCOUNT_ID=...

wrangler kv namespace create PUSH_SUBSCRIPTIONS
node scripts/generate-vapid-keypair.js

# For a NEW Pages project:
wrangler pages project create <project-name> --production-branch=main --compatibility-date=<date>
# wrangler.toml (gitignored) in the project root:
#   name = "<project-name>"
#   pages_build_output_dir = "build"
#   compatibility_date = "<date>"
#   [[kv_namespaces]]
#   binding = "PUSH_SUBSCRIPTIONS"
#   id = "<namespace-id>"
#   [vars]
#   VAPID_PUBLIC_KEY = "<from keygen>"
#   VAPID_SUBJECT = "https://<your-domain>"
npm run build && wrangler pages deploy --project-name=<project-name> --branch=main

# For an EXISTING project (e.g. impro.social), bind + set vars directly via
# the API instead (dashboard -> Settings -> Functions/Environment variables
# works too):
curl -X PATCH "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/<project-name>" \
  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" -H "Content-Type: application/json" \
  -d '{"deployment_configs":{"production":{
    "kv_namespaces":{"PUSH_SUBSCRIPTIONS":{"namespace_id":"<id>"}},
    "env_vars":{
      "VAPID_PUBLIC_KEY":{"type":"plain_text","value":"<key>"},
      "VAPID_SUBJECT":{"type":"plain_text","value":"https://<your-domain>"}
    }
  }}}'

# Either way, the private key is a secret, and secrets/bindings don't apply
# retroactively -- a fresh deployment is needed after this step:
wrangler pages secret put VAPID_PRIVATE_JWK --project-name=<project-name>
wrangler pages deploy --project-name=<project-name> --branch=main   # or: next push to main, if git-connected

# Verify:
curl https://<your-domain>/push/vapid-public-key   # {"key":"..."} once live, 501 until then
```

Live debugging if something goes wrong: `wrangler pages deployment tail <deployment-id> --project-name=<project-name>` streams real server-side exceptions from the Functions in real time.

### Things worth knowing about, not just doing

- **Cloudflare KV enforces a hard minimum `expirationTtl` of 60 seconds.** Already handled correctly here (the throttle keys in `functions/push/subscribe.js`/`relay.js` use 60s), but worth knowing if those constants ever get tuned down later — a lower value fails the KV write outright rather than clamping, and takes the whole request down with it. This is exactly the bug that made every real subscribe/relay attempt fail during initial device testing; the automated tests don't catch it since KV isn't emulated in the unit/e2e setup at all.
- **Workers KV free tier is 100k reads/day and 1,000 writes/day.** Fine for testing, worth watching at real scale — every subscribe, unsubscribe, relay call, and the throttle key on each of those, is a write. Cloudflare's $5/mo Workers Paid plan raises this substantially if it's ever a concern; nothing in the code needs to change either way.

## Testing

- Unit: full suite (4051 tests) passes; no dedicated new unit tests for the Functions themselves (Workers KV/Functions aren't emulated in the existing unit/e2e setup, see above).
- **Real devices**: tested end-to-end against a live Cloudflare Pages deployment (real KV + VAPID, not mocked) on **Chrome on Android** and **Firefox on Linux (desktop)** — enabled the relay on both, confirmed a real push notification arrives on one device when the other detects new activity via its own polling.
- If you want to poke at a real deployment yourselves rather than just reading the diff: our test site (a personal deployment, unrelated to impro.social) has this fully configured end-to-end. Happy to share the URL if useful for review.

