### PR TITLE
Fix effect() permanently dying after an uncaught exception

### DIFF
--- a/src/js/signals.js
+++ b/src/js/signals.js
@@ -116,7 +116,13 @@ export const effect = (cb, { debugName, debugDepth } = {}) => {
   const run = () => {
     const prevRunTick = lastRunTick;
     ranThisFlush = false;
-    computed.get();
+    try {
+      computed.get();
+    } finally {
+      // Re-arm even if the callback threw -- otherwise one uncaught error
+      // permanently stops this effect from ever reacting again.
+      watcher.watch();
+    }
     if (ranThisFlush) {
       if (hasRun && debugName) {
         logEffectTrigger(computed, debugName, debugDepth, prevRunTick);
@@ -124,7 +130,6 @@ export const effect = (cb, { debugName, debugDepth } = {}) => {
       lastRunTick = globalTick;
       hasRun = true;
     }
-    watcher.watch(); // re-arm
   };
 
   const watcher = new PolyfillSignal.subtle.Watcher(() => {

--- a/tests/unit/specs/signals.test.js
+++ b/tests/unit/specs/signals.test.js
@@ -1,6 +1,20 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { Signal, SignalSet, SignalMap, SignalArray } from "/js/signals.js";
+import {
+  Signal,
+  SignalSet,
+  SignalMap,
+  SignalArray,
+  effect,
+} from "/js/signals.js";
+
+// effect() batches reactions via a double requestAnimationFrame (see
+// signals.js) - this waits for that flush to actually happen.
+function flushEffects() {
+  return new Promise((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(resolve)),
+  );
+}
 
 describe("SignalSet - Set behavior", () => {
   it("starts empty by default", () => {
@@ -511,5 +525,87 @@ describe("SignalArray - reactivity", () => {
     arr.replace(["a", "b"]);
     assert.deepEqual($length.get(), 2);
     assert.deepEqual(runs, 2);
+  });
+});
+
+describe("effect", () => {
+  it("re-runs when a read signal changes", async () => {
+    const $count = new Signal.State(0);
+    const seen = [];
+    const dispose = effect(() => {
+      seen.push($count.get());
+    });
+    try {
+      $count.set(1);
+      await flushEffects();
+      assert.deepEqual(seen, [0, 1]);
+    } finally {
+      dispose();
+    }
+  });
+
+  it("keeps reacting to future changes even after the callback throws", () => {
+    // effect() schedules its reaction inside a requestAnimationFrame
+    // callback. An exception thrown there is a genuinely uncaught
+    // exception (same as in a real browser) - not something a surrounding
+    // try/catch or .catch() can observe, and node:test fails the test for
+    // any uncaught exception during its run regardless of handlers.
+    //
+    // Auto-running rAF synchronously doesn't work either: it would fire
+    // while still inside the signal's own change-notification dispatch
+    // (reentrantly), which trips the signal library's own reentrancy guard
+    // instead of exercising our code at all. Instead, capture the pending
+    // rAF callback and invoke it manually, after set() has already
+    // returned -- that's a plain synchronous call in our own test code, so
+    // a normal try/catch works and nothing is ever actually "uncaught".
+    const originalRaf = globalThis.requestAnimationFrame;
+    let pendingRaf = null;
+    globalThis.requestAnimationFrame = (cb) => {
+      pendingRaf = cb;
+    };
+    try {
+      const $count = new Signal.State(0);
+      const seen = [];
+      const dispose = effect(() => {
+        const value = $count.get();
+        seen.push(value);
+        if (value === 1) {
+          throw new Error("boom");
+        }
+      });
+      try {
+        $count.set(1);
+        assert.ok(pendingRaf, "expected a reaction to be scheduled");
+        assert.throws(() => pendingRaf(), /boom/);
+
+        // The regression this guards against: a naive implementation stops
+        // re-arming its watcher once the callback throws, so this second
+        // change would silently never be observed.
+        pendingRaf = null;
+        $count.set(2);
+        assert.ok(pendingRaf, "expected the effect to still be re-armed");
+        pendingRaf();
+
+        assert.deepEqual(seen, [0, 1, 2]);
+      } finally {
+        dispose();
+      }
+    } finally {
+      globalThis.requestAnimationFrame = originalRaf;
+    }
+  });
+
+  it("stops reacting after dispose", async () => {
+    const $count = new Signal.State(0);
+    const seen = [];
+    const dispose = effect(() => {
+      seen.push($count.get());
+    });
+    dispose();
+
+    $count.set(1);
+    await flushEffects();
+
+    assert.deepEqual(seen, [0]);
   });
 });


### PR DESCRIPTION
## Summary

`effect()`'s `run()` called `computed.get()` (which invokes the effect's callback) without a try/finally around the watcher re-arm:

```js
const run = () => {
  ...
  computed.get();       // if this throws, we never reach the line below
  if (ranThisFlush) { ... }
  watcher.watch();       // re-arm
};
```

If the callback throws — for any reason, anywhere in whatever it renders or touches — execution never reaches `watcher.watch()`. The effect stops reacting to signal changes **forever** afterward, silently, with no crash. Only a full page reload (which constructs a brand new effect from scratch) recovers it.

This isn't scoped to one feature — it affects every `effect()` caller in the app. `mainLayout.js`'s sidebar/badge rendering is exactly as exposed as anything else: a single transient error anywhere in a render path permanently freezes that reactive subscription until the user manually reloads.

## Fix

Wrap the `computed.get()` call in try/finally so the watcher always re-arms, regardless of whether the callback succeeded:

```js
try {
  computed.get();
} finally {
  watcher.watch(); // re-arm even if the callback threw
}
```

The exception itself still propagates and still surfaces as an uncaught error — this doesn't swallow or hide bugs, it just stops one thrown error from taking down the whole reactive subscription with it.

## Testing

Added regression coverage in `signals.test.js` exercising the exact failure mode: an effect whose callback throws once must still react to the next signal change afterward. Getting a deterministic test for this required some care — `effect()` schedules reactions via `requestAnimationFrame`, and an exception thrown there is a genuinely uncaught exception (not something `try/catch`/`.catch()` around the trigger can observe), which `node:test` also flags as a test failure regardless of handlers. The test works around this by capturing the pending rAF callback and invoking it manually, after `set()` has already returned (avoiding a reentrancy issue that comes from forcing rAF fully synchronous instead) — so the throw happens as a plain synchronous call in the test's own code, where a normal `try/catch` genuinely works.

Verified this is a meaningful regression test, not just green-by-construction: it fails with the predicted symptom ("expected the effect to still be re-armed") when run against the pre-fix code, and passes with the fix applied.

Full unit suite passes (4124/4124).
