### PR TITLE
Record what a real deployment of the notification spec turned up

### DIFF
--- a/specs/bsky-push-notification-service.md
+++ b/specs/bsky-push-notification-service.md
@@ -1,6 +1,6 @@
 # Bluesky Push Notification Service Spec
 
-#### Version: 0.0.1
+#### Version: 0.0.2
 
 The normative interface between a Bluesky client (an app built on the
 `app.bsky.*` appview and `chat.bsky.*` chat services) and a push
@@ -27,6 +27,14 @@ This is the shape PDS request forwarding already resolves
 own origin is the expected common case, but any DID method that can
 publish the entry works. Everything below is served from the
 `serviceEndpoint` origin.
+
+A `did:web` document MUST be served with permissive CORS, for the same
+reason the config document below must be: a browser client resolves it
+cross-origin, and it is the *first* thing it fetches — before it knows
+the service's endpoint at all. A service that serves its DID document
+as a static file alongside the application is the likely place to miss
+this, since the application's own responses may set those headers in
+code that never runs for a static file.
 
 ## Config document
 
@@ -76,6 +84,18 @@ browser to it and receives it back:
      the message-content scope (see "Grant tiers")
 2. The service runs the standard atproto OAuth flow under its own
    `client_id` and stores the grant server-side.
+   - The PDS is not necessarily its own authorization server. Resolve
+     the AS from the PDS with RFC 9728 — `GET
+     <pds>/.well-known/oauth-protected-resource`, then
+     `authorization_servers[0]` — and read
+     `/.well-known/oauth-authorization-server` from *that* origin. For
+     accounts hosted on `bsky.social` the two differ, and a service
+     that assumes the PDS is the AS fails against every such account
+     while working perfectly against a PDS that happens to be both.
+   - The service's client metadata document MUST declare a `scope`
+     covering the union of both grant tiers. Authorization servers
+     validate every pushed authorization request's scopes against this
+     list, so omitting it fails 100% of authorizations.
 3. The service MUST verify the completed grant's `sub` matches the
    hinted DID before storing it.
 4. The service redirects to `return_url`, appending standard OAuth
@@ -116,6 +136,16 @@ Grant lifecycle expectations:
   or revoked by the user at their PDS): delete it and all stored
   state for that DID; the user re-authorizes through `authUrl`.
   PDS-side revocation is the immediate account-wide teardown path.
+- A failure that is about the *service* rather than the grant MUST NOT
+  be treated as grant death, and SHOULD NOT count toward any
+  per-account give-up threshold. The authorization server reporting
+  that it cannot read the service's own client metadata
+  (`invalid_client_metadata`, `invalid_client`,
+  `unauthorized_client`) is the clearest case: it says nothing about
+  any particular grant and fails identically for every account at
+  once. A service that counts these per-account converts one outage of
+  its own metadata endpoint into a forced re-authorization for its
+  entire user base. Back off, keep the grant.
 
 ## Device registration
 
@@ -134,6 +164,15 @@ called method. This JWT is the sole authentication — it is what makes
 registration sound for unauthed services too, since nobody can
 register a device against a DID they do not control.
 
+Signature verification MUST accept both `ES256` (P-256) and `ES256K`
+(secp256k1). secp256k1 is atproto's long-standing default signing key
+type and the large majority of live accounts use it; a service that
+implements P-256 only will pass every test written against P-256
+fixtures and then reject almost every real user. The curve is
+identified by the multicodec prefix of the DID document's
+`publicKeyMultibase` — `0xe701` for secp256k1, `0x8024` for P-256 —
+not by the JWT header alone.
+
 Token formats by `platform`:
 
 - `web` — `token` is the serialized `PushSubscription` JSON:
@@ -145,6 +184,21 @@ Clients re-assert registration on every launch — there is no API to
 query registration state, and this is the self-healing mechanism for
 rotated or lost tokens. `unregisterPush` deletes the single matching
 device row.
+
+Neither procedure defines a lexicon output. Services SHOULD answer
+with an empty `200`, and clients MUST NOT assume a JSON body: a PDS
+may forward an empty body on success regardless of what the service
+returned, so a client that unconditionally parses the response throws
+on exactly the requests that succeeded.
+
+Re-assertion is also the only liveness signal this interface has.
+Beyond launch, clients SHOULD re-assert while the app is in the
+foreground — a few minutes apart is enough — and stop while
+backgrounded, so that going away is itself a signal. A service that
+polls MAY use the recency of registration to pick its poll cadence.
+Without this, an open and actively-read client is indistinguishable
+from an abandoned one, and a user watching the app receives pushes on
+whatever slow cadence the service reserves for dormant accounts.
 
 `appId` identifies the client app and MUST be stored per device, so one service can serve several apps.
 
@@ -174,12 +228,38 @@ VAPID key. The plaintext is JSON:
 - `url` — required; deeplink, path-relative to the client app's
   origin. The client's service worker resolves it against its own
   origin (the service does not know or care where the client is
-  hosted).
+  hosted). Since only the path is shared, both sides must agree on
+  its shape:
+
+  ```
+  /profile/<handle-or-did>
+  /profile/<handle-or-did>/post/<rkey>
+  /messages/<convoId>
+  ```
+
+  The target is the record the notification is *about*, not the
+  notification's own `uri`. For `reply`, `mention`, `quote`, and
+  `subscribed-post` those are the same record. For `like` and
+  `repost` they are not: the notification's `uri` is the reaction
+  record, which lives in the *reacting* account's repo, so a post
+  link built from it names a post that does not exist. Follow the
+  reaction to its subject instead — `reasonSubject` for plain `like`
+  and `repost`, `record.subject.uri` for the `-via-repost` variants,
+  where `reasonSubject` is the reader's own repost rather than the
+  post itself. `follow` has no post at all and links to the follower.
+  Getting this wrong is not subtle in use: every like notification
+  opens a blank page.
 - `badge` — optional; total unread count at send time. Best-effort:
   reads on other devices cannot update it until the next push.
 - `tag` — optional collapse key: a new notification with the same tag
   replaces the previous one. Counts-tier chat pushes SHOULD use a stable
   tag so an unread pile-up is one notification, not a stack.
+  Previews-tier chat pushes SHOULD collapse per conversation
+  (`chat:<convoId>`) rather than globally. Because each push then
+  replaces the last one for that conversation, a previews push SHOULD
+  carry the recent exchange rather than only the newest message —
+  otherwise a fast back-and-forth is unreadable from the banner, which
+  is the one place the previews tier exists to be read.
 
 **APNs** payloads map the same fields: `title`/`body` into
 `aps.alert`, `badge` into `aps.badge`, `tag` into
@@ -191,6 +271,33 @@ A `404` or `410` from a Web Push endpoint means the subscription is
 dead: the service MUST delete the device row (this is the only
 reliable unsubscribe signal, and it feeds the zero-device grant
 lifecycle above). Other failures are retried with backoff.
+
+A newly stored grant MUST establish its delivery baseline from the
+account's current state — unread counts, and for the previews tier the
+chat log cursor at its head — before the first poll. Activity that
+predates registration is not new. A service that baselines at zero
+reads the account's existing backlog as its first delta and delivers
+all of it, so enabling notifications is immediately followed by a
+burst of pushes for things the user read days ago. The chat log is the
+sharper version of this, since it contains read messages too.
+
+A service MUST NOT push the subscriber's own activity back to them.
+`chat.bsky.convo.getLog` returns everything said in a conversation,
+including the subscriber's own messages; the appview already
+suppresses self-notifications on the `app.bsky` side, and a chat
+delivery path that does not do the same notifies people about their
+own typing. Own messages are legitimate as *context* in a previews
+push, marked as the reader's own — they simply must never be the
+event that triggers one.
+
+A service SHOULD collapse a large burst of app notifications into one
+summarizing push rather than sending them individually. Beyond being
+unreadable, a rapid burst of individual notifications is what
+browsers' abusive-notification heuristics are built to catch — Chrome
+on Android flagged exactly this during a real deployment of this spec.
+That enforcement applies to the origin rather than to the one user who
+received the burst, so the cost of getting it wrong is borne by every
+user of the client.
 
 ## Security requirements
 

--- a/specs/bsky-push-notification-service.md
+++ b/specs/bsky-push-notification-service.md
@@ -185,20 +185,6 @@ VAPID key. The plaintext is JSON:
   origin. The client's service worker resolves it against its own
   origin (the service does not know or care where the client is
   hosted).
-
-  The target is the record the notification is _about_, not the
-  notification's own `uri`. For `reply`, `mention`, `quote`, and
-  `subscribed-post` those are the same record. For `like` and
-  `repost` they are not: the notification's `uri` is the reaction
-  record, which lives in the _reacting_ account's repo, so a post
-  link built from it names a post that does not exist. Follow the
-  reaction to its subject instead — `reasonSubject` for plain `like`
-  and `repost`, `record.subject.uri` for the `-via-repost` variants,
-  where `reasonSubject` is the reader's own repost rather than the
-  post itself. `follow` has no post at all and links to the follower.
-  Getting this wrong is not subtle in use: every like notification
-  opens a blank page.
-
 - `badge` — optional; total unread count at send time. Best-effort:
   reads on other devices cannot update it until the next push.
 - `tag` — optional collapse key: a new notification with the same tag

--- a/specs/bsky-push-notification-service.md
+++ b/specs/bsky-push-notification-service.md
@@ -202,24 +202,6 @@ dead: the service MUST delete the device row (this is the only
 reliable unsubscribe signal, and it feeds the zero-device grant
 lifecycle above). Other failures are retried with backoff.
 
-A newly stored grant MUST establish its delivery baseline from the
-account's current state — unread counts, and for the previews tier the
-chat log cursor at its head — before the first poll. Activity that
-predates registration is not new. A service that baselines at zero
-reads the account's existing backlog as its first delta and delivers
-all of it, so enabling notifications is immediately followed by a
-burst of pushes for things the user read days ago. The chat log is the
-sharper version of this, since it contains read messages too.
-
-A service MUST NOT push the subscriber's own activity back to them.
-`chat.bsky.convo.getLog` returns everything said in a conversation,
-including the subscriber's own messages; the appview already
-suppresses self-notifications on the `app.bsky` side, and a chat
-delivery path that does not do the same notifies people about their
-own typing. Own messages are legitimate as _context_ in a previews
-push, marked as the reader's own — they simply must never be the
-event that triggers one.
-
 A service SHOULD collapse a large burst of app notifications into a
 summary rather than sending them individually. A rapid burst of
 notifications can trigger browsers' abusive-notification checks.

--- a/specs/bsky-push-notification-service.md
+++ b/specs/bsky-push-notification-service.md
@@ -28,13 +28,9 @@ own origin is the expected common case, but any DID method that can
 publish the entry works. Everything below is served from the
 `serviceEndpoint` origin.
 
-A `did:web` document MUST be served with permissive CORS, for the same
-reason the config document below must be: a browser client resolves it
-cross-origin, and it is the *first* thing it fetches — before it knows
-the service's endpoint at all. A service that serves its DID document
-as a static file alongside the application is the likely place to miss
-this, since the application's own responses may set those headers in
-code that never runs for a static file.
+A `did:web` document MUST be served with permissive CORS,
+(`Access-Control-Allow-Origin: *`) — clients fetch it cross-origin
+from the browser.
 
 ## Config document
 
@@ -84,18 +80,8 @@ browser to it and receives it back:
      the message-content scope (see "Grant tiers")
 2. The service runs the standard atproto OAuth flow under its own
    `client_id` and stores the grant server-side.
-   - The PDS is not necessarily its own authorization server. Resolve
-     the AS from the PDS with RFC 9728 — `GET
-     <pds>/.well-known/oauth-protected-resource`, then
-     `authorization_servers[0]` — and read
-     `/.well-known/oauth-authorization-server` from *that* origin. For
-     accounts hosted on `bsky.social` the two differ, and a service
-     that assumes the PDS is the AS fails against every such account
-     while working perfectly against a PDS that happens to be both.
    - The service's client metadata document MUST declare a `scope`
-     covering the union of both grant tiers. Authorization servers
-     validate every pushed authorization request's scopes against this
-     list, so omitting it fails 100% of authorizations.
+     covering the union of both grant tiers.
 3. The service MUST verify the completed grant's `sub` matches the
    hinted DID before storing it.
 4. The service redirects to `return_url`, appending standard OAuth
@@ -136,16 +122,6 @@ Grant lifecycle expectations:
   or revoked by the user at their PDS): delete it and all stored
   state for that DID; the user re-authorizes through `authUrl`.
   PDS-side revocation is the immediate account-wide teardown path.
-- A failure that is about the *service* rather than the grant MUST NOT
-  be treated as grant death, and SHOULD NOT count toward any
-  per-account give-up threshold. The authorization server reporting
-  that it cannot read the service's own client metadata
-  (`invalid_client_metadata`, `invalid_client`,
-  `unauthorized_client`) is the clearest case: it says nothing about
-  any particular grant and fails identically for every account at
-  once. A service that counts these per-account converts one outage of
-  its own metadata endpoint into a forced re-authorization for its
-  entire user base. Back off, keep the grant.
 
 ## Device registration
 
@@ -165,13 +141,8 @@ registration sound for unauthed services too, since nobody can
 register a device against a DID they do not control.
 
 Signature verification MUST accept both `ES256` (P-256) and `ES256K`
-(secp256k1). secp256k1 is atproto's long-standing default signing key
-type and the large majority of live accounts use it; a service that
-implements P-256 only will pass every test written against P-256
-fixtures and then reject almost every real user. The curve is
-identified by the multicodec prefix of the DID document's
-`publicKeyMultibase` — `0xe701` for secp256k1, `0x8024` for P-256 —
-not by the JWT header alone.
+(secp256k1). Derive the algorithm from the resolved key in the DID
+document, not from the JWT header's `alg`.
 
 Token formats by `platform`:
 
@@ -184,21 +155,6 @@ Clients re-assert registration on every launch — there is no API to
 query registration state, and this is the self-healing mechanism for
 rotated or lost tokens. `unregisterPush` deletes the single matching
 device row.
-
-Neither procedure defines a lexicon output. Services SHOULD answer
-with an empty `200`, and clients MUST NOT assume a JSON body: a PDS
-may forward an empty body on success regardless of what the service
-returned, so a client that unconditionally parses the response throws
-on exactly the requests that succeeded.
-
-Re-assertion is also the only liveness signal this interface has.
-Beyond launch, clients SHOULD re-assert while the app is in the
-foreground — a few minutes apart is enough — and stop while
-backgrounded, so that going away is itself a signal. A service that
-polls MAY use the recency of registration to pick its poll cadence.
-Without this, an open and actively-read client is indistinguishable
-from an abandoned one, and a user watching the app receives pushes on
-whatever slow cadence the service reserves for dormant accounts.
 
 `appId` identifies the client app and MUST be stored per device, so one service can serve several apps.
 
@@ -228,20 +184,13 @@ VAPID key. The plaintext is JSON:
 - `url` — required; deeplink, path-relative to the client app's
   origin. The client's service worker resolves it against its own
   origin (the service does not know or care where the client is
-  hosted). Since only the path is shared, both sides must agree on
-  its shape:
+  hosted).
 
-  ```
-  /profile/<handle-or-did>
-  /profile/<handle-or-did>/post/<rkey>
-  /messages/<convoId>
-  ```
-
-  The target is the record the notification is *about*, not the
+  The target is the record the notification is _about_, not the
   notification's own `uri`. For `reply`, `mention`, `quote`, and
   `subscribed-post` those are the same record. For `like` and
   `repost` they are not: the notification's `uri` is the reaction
-  record, which lives in the *reacting* account's repo, so a post
+  record, which lives in the _reacting_ account's repo, so a post
   link built from it names a post that does not exist. Follow the
   reaction to its subject instead — `reasonSubject` for plain `like`
   and `repost`, `record.subject.uri` for the `-via-repost` variants,
@@ -249,17 +198,12 @@ VAPID key. The plaintext is JSON:
   post itself. `follow` has no post at all and links to the follower.
   Getting this wrong is not subtle in use: every like notification
   opens a blank page.
+
 - `badge` — optional; total unread count at send time. Best-effort:
   reads on other devices cannot update it until the next push.
 - `tag` — optional collapse key: a new notification with the same tag
   replaces the previous one. Counts-tier chat pushes SHOULD use a stable
   tag so an unread pile-up is one notification, not a stack.
-  Previews-tier chat pushes SHOULD collapse per conversation
-  (`chat:<convoId>`) rather than globally. Because each push then
-  replaces the last one for that conversation, a previews push SHOULD
-  carry the recent exchange rather than only the newest message —
-  otherwise a fast back-and-forth is unreadable from the banner, which
-  is the one place the previews tier exists to be read.
 
 **APNs** payloads map the same fields: `title`/`body` into
 `aps.alert`, `badge` into `aps.badge`, `tag` into
@@ -286,18 +230,13 @@ A service MUST NOT push the subscriber's own activity back to them.
 including the subscriber's own messages; the appview already
 suppresses self-notifications on the `app.bsky` side, and a chat
 delivery path that does not do the same notifies people about their
-own typing. Own messages are legitimate as *context* in a previews
+own typing. Own messages are legitimate as _context_ in a previews
 push, marked as the reader's own — they simply must never be the
 event that triggers one.
 
-A service SHOULD collapse a large burst of app notifications into one
-summarizing push rather than sending them individually. Beyond being
-unreadable, a rapid burst of individual notifications is what
-browsers' abusive-notification heuristics are built to catch — Chrome
-on Android flagged exactly this during a real deployment of this spec.
-That enforcement applies to the origin rather than to the one user who
-received the burst, so the cost of getting it wrong is borne by every
-user of the client.
+A service SHOULD collapse a large burst of app notifications into a
+summary rather than sending them individually. A rapid burst of
+notifications can trigger browsers' abusive-notification checks.
 
 ## Security requirements
 


### PR DESCRIPTION
Following up on your ask in #39 — here's what running a service against this spec, with a live client pointed at it, turned up that the document doesn't currently say.

Grouping them by how they fail, because that's the useful axis:

### Things that fail silently, or only against real infrastructure

These are the ones I'd most want in the document. Each passes happily against test fixtures and then fails against production.

**secp256k1 service-auth JWTs.** The spec says to verify the signature against the caller's DID keys but not with what. secp256k1 is atproto's long-standing default key type and the large majority of live accounts use it — so a P-256-only verifier passes every test written against P-256 fixtures and then rejects almost every real user at `registerPush`. Added the requirement plus how to tell the curves apart (the multibase prefix, `0xe701` vs `0x8024`, not the JWT header).

**The PDS is often not its own authorization server.** For `bsky.social`-hosted accounts the AS is a separate entryway origin, discovered via RFC 9728 `/.well-known/oauth-protected-resource`. A service that assumes PDS == AS works perfectly against a PDS that happens to be both, and fails against every account that isn't. This one cost me a while, since the error surfaces as a JSON parse failure on an HTML 404 page.

**Client metadata must declare a `scope`.** Real authorization servers validate every PAR request's scopes against the client metadata document's own `scope` list. Omit the field and *100%* of authorizations fail.

**CORS on the `did:web` document.** The spec already requires it for the config document, for exactly the right reason — but the DID document is the *first* thing a browser client fetches, before it knows the service endpoint at all. It's also the one most likely to be served as a static file by a webserver that never runs the application's header code, which is precisely how I missed it.

**`registerPush`/`unregisterPush` have no lexicon output.** A PDS may forward an empty body on success regardless of what the service returned, so a client that unconditionally parses JSON throws on exactly the requests that worked. Cost me a round of "registration failed" reports for registrations that had in fact succeeded.

### Deeplinks

**The `url` target is the record the notification is *about*, not the notification's own `uri`.** They're the same record for `reply`/`mention`/`quote`/`subscribed-post`. They are not for `like` and `repost`: there the `uri` is the *reaction* record, which lives in the reacting account's repo — so a post link built from it names a post that doesn't exist, and every like notification opens a blank page. Follow `reasonSubject` for plain likes/reposts, and `record.subject.uri` for the `-via-repost` variants, where `reasonSubject` is the reader's own repost rather than the post.

I also wrote down the three canonical path shapes (`/profile/<handle-or-did>`, `/profile/<handle-or-did>/post/<rkey>`, `/messages/<convoId>`). This is the piece I'm least sure belongs in *this* document, since it's really a client routing convention — but since the spec says the service sends a path and the client resolves it against its own origin, the field doesn't mean anything unless both sides agree on the shape. Very happy to drop it or move it if you'd rather it not be normative here.

### Delivery behaviour

**Baseline a new grant at the account's current state.** Not zero — otherwise the first poll reads the whole existing backlog as its delta, and enabling notifications is immediately followed by a burst of pushes for things the user read days ago. The chat log is the sharper version, since it contains *read* messages too.

**Never push the subscriber's own messages back at them.** `getLog` returns everything said in a conversation, own messages included. The appview already suppresses self-notifications on the `app.bsky` side; the chat path has to do it deliberately. (Own messages are still useful as *context* in a previews push — just never the trigger.)

**Collapse bursts.** This is the one I mentioned in #39: Chrome on Android's abusive-notification heuristics flagged the uncollapsed version. Worth stating as a SHOULD because the enforcement lands on the *origin*, so one badly-behaved service costs every user of the client, not just whoever got the burst.

**Previews-tier chat should collapse per conversation, and carry context.** Follows from `tag`: if each push replaces the last one for that conversation, a fast back-and-forth becomes unreadable — you only ever see the newest line — which defeats the point of the previews tier.

**Re-assertion as a liveness signal.** The spec has clients re-asserting at launch. Extending that slightly: it's the *only* liveness signal this interface has, so clients doing it periodically while foregrounded (and stopping while backgrounded) lets a polling service tell an actively-read client from an abandoned one. Without it, a user staring at the app gets pushes on whatever cadence the service reserves for dormant accounts.

### One from a few hours ago

**A failure about the *service* is not a dead grant.** The spec correctly says `invalid_grant` means teardown. The complement wasn't stated, and I only hit it tonight: an authorization server reporting it can't read the *service's* client metadata says nothing about any particular grant, and fails identically for every account at once. A service that counts those toward a per-account give-up threshold converts a single outage of its own metadata endpoint into a forced re-authorization for its entire user base. Back off, keep the grant.

(That one showed up as a single transient failure in production, self-healed on the next poll, and then I went and looked at what *would* have happened if it hadn't been transient. The reference implementation now distinguishes the two classes, with a conformance case pinning it.)

---

### Deliberately left out

The `chat.bsky.convo.getUnreadCounts` response-shape trap — the real service answers `{unreadAcceptedConvos, unreadRequestConvos}` where fixtures often use `{count}`, and reading only `count` pins the total at zero forever with no error anywhere, so chat pushes simply never fire. That's a service↔appview concern rather than client↔service, so it seemed out of scope here. It's written up [in the courierbench README](https://tangled.org/7778777.online/courierbench/blob/master/README.md#beyond-the-benchmark-contract) along with the rest of the real-world gaps, if it's useful.

### Notes

Version bumped `0.0.1` → `0.0.2`; happy to drop that if you'd rather it track differently.

Everything here comes from a service that's been running against real accounts and a client that's been talking to it — the live instance behind #39. Each of these is a separate concern and I've tried to keep them independent in the text, so please take or drop them individually. If it'd be easier to review as several smaller PRs, say the word and I'll split it.
