### PR TITLE
Say what the deeplink points at

### DIFF
--- a/specs/bsky-push-notification-service.md
+++ b/specs/bsky-push-notification-service.md
@@ -28,7 +28,7 @@ own origin is the expected common case, but any DID method that can
 publish the entry works. Everything below is served from the
 `serviceEndpoint` origin.
 
-A `did:web` document MUST be served with permissive CORS,
+A `did:web` document MUST be served with permissive CORS
 (`Access-Control-Allow-Origin: *`) — clients fetch it cross-origin
 from the browser.
 
@@ -184,7 +184,12 @@ VAPID key. The plaintext is JSON:
 - `url` — required; deeplink, path-relative to the client app's
   origin. The client's service worker resolves it against its own
   origin (the service does not know or care where the client is
-  hosted).
+  hosted). The deeplink MUST target the record the notification is
+  about. For `like`, `repost`, and the `-via-repost` variants that is
+  the reaction's subject, not the notification's own `uri` — which is
+  the reaction record, in the reacting account's repo. Note that
+  `reasonSubject` is the reader's own repost for the `-via-repost`
+  variants, so those take the subject from the reaction record.
 - `badge` — optional; total unread count at send time. Best-effort:
   reads on other devices cannot update it until the next push.
 - `tag` — optional collapse key: a new notification with the same tag


### PR DESCRIPTION
Small follow-up to #42 — the scoping down was right, and the spec reads much better as requirements without the war stories. Deriving the algorithm from the resolved key rather than the JWT header is a better rule than the one I wrote, too.

One thing I think may have gone out with the bathwater, so raising it rather than assuming. "Remove notification path details" took out two things that were sitting in the same block:

- the **path shapes** (`/profile/<handle>/post/<rkey>` and friends) — client routing, correctly gone, that was the bit I'd flagged as your call
- the rule about **which record the `url` points at** — which is about the meaning of a field this document defines, not about routing

It's the second one I'd argue for. A service that builds the deeplink from the notification's own `uri` emits a `url` that no client can render: for a `like` or `repost` that `uri` is the *reaction* record, living in the reacting account's repo, so the link names a post that doesn't exist. Concretely, every like notification opens a blank page — which is exactly what the demo instance did until I fixed it.

Written to fit the document's register now, no rationale, no path syntax. The `reasonSubject` caveat is in there because it's the trap in implementing the rule: it's the right subject for a plain like or repost, but for the `-via-repost` variants it's the reader's *own repost*, so following it lands somewhere worse than not following it at all.

Also drops a stray comma in the `did:web` CORS sentence so it matches the identical sentence in the config document section.

If you did mean to drop the whole block, close this — no argument from me, it's your document and you've got a clearer view of what belongs in it than I do.
