### PR TITLE
Let plugins request one user-approved custom network endpoint

### DIFF
--- a/impro-plugin/docs/docs.md
+++ b/impro-plugin/docs/docs.md
@@ -15,6 +15,7 @@ The plugin's handle to the running impro app. Exposed as `this.app` on a
 | Property | Type | Description |
 | ------ | ------ | ------ |
 | <a id="property-currentuser"></a> `currentUser` | [`ProfileView`](#profileview) \| `null` | The signed-in user's basic profile, populated before `onload()` runs. Null when no session is active. |
+| <a id="property-customendpoint"></a> `customEndpoint` | [`CustomEndpoint`](#customendpoint) | A user-approved network address — see [CustomEndpoint](#customendpoint). |
 | <a id="property-data"></a> `data` | [`PluginData`](#plugindata) | Read-only appview accessors — see [PluginData](#plugindata). |
 
 #### Methods
@@ -390,6 +391,84 @@ Replace the composer's current text.
 ###### Returns
 
 [`Composer`](#composer)
+
+***
+
+### CustomEndpoint
+
+Lets a plugin talk to one network address a human has personally typed
+into its settings and approved — not a manifest-declared allowlist like
+[fetch](#fetch-1), and not "any address": [CustomEndpoint.requestUrl](#requesturl)
+always re-prompts the user with the exact address before it takes effect,
+and [CustomEndpoint.fetch](#fetch) only ever succeeds against that one
+approved address. Unlike the manifest-gated [fetch](#fetch-1), non-`https:`
+addresses (e.g. a local Ollama server on `http://localhost:11434`) and an
+`Authorization` header are both allowed — it's the plugin's own
+credential for an address the user explicitly approved, not an ambient
+one being smuggled to an unreviewed third-party host. Requires the
+`"customEndpoint"` scope in the manifest's `permissions.network`.
+
+#### Constructors
+
+##### Constructor
+
+> **new CustomEndpoint**(): [`CustomEndpoint`](#customendpoint)
+
+###### Returns
+
+[`CustomEndpoint`](#customendpoint)
+
+#### Methods
+
+##### fetch()
+
+> **fetch**(`url`, `init?`): `Promise`\<[`PluginResponse`](#pluginresponse)\>
+
+Fetches `url`, which must exactly match the currently-approved address
+(see [CustomEndpoint.requestUrl](#requesturl)) or this rejects.
+
+###### Parameters
+
+| Parameter | Type |
+| ------ | ------ |
+| `url` | `string` |
+| `init?` | [`PluginFetchInit`](#pluginfetchinit) |
+
+###### Returns
+
+`Promise`\<[`PluginResponse`](#pluginresponse)\>
+
+##### getUrl()
+
+> **getUrl**(): `Promise`\<`string` \| `null`\>
+
+The currently-approved URL, or null if none has been approved yet (or
+it was cleared, e.g. by uninstalling and reinstalling the plugin).
+
+###### Returns
+
+`Promise`\<`string` \| `null`\>
+
+##### requestUrl()
+
+> **requestUrl**(`url`): `Promise`\<\{ `accepted`: `boolean`; `url`: `string` \| `null`; \}\>
+
+Prompts the user to approve `url` as this plugin's one allowed network
+address.
+
+###### Parameters
+
+| Parameter | Type |
+| ------ | ------ |
+| `url` | `string` |
+
+###### Returns
+
+`Promise`\<\{ `accepted`: `boolean`; `url`: `string` \| `null`; \}\>
+
+`url` is
+  the *current* approved address (unchanged from before if declined);
+  `accepted` reflects whether this particular request was granted.
 
 ***
 
@@ -1268,7 +1347,7 @@ Fetch a raw repo record by `(repo, collection, rkey)`.
 
 ### PluginResponse
 
-Response returned from [fetch](#fetch). The host buffers the raw response
+Response returned from [fetch](#fetch-1). The host buffers the raw response
 bytes and sends them as an `ArrayBuffer`, and this class decodes them on
 demand depending on which accessor is called. `status`, `ok`, and `headers`
 (a `Map`) mirror the underlying HTTP response.
@@ -2362,7 +2441,7 @@ The events Plugin.on accepts, and the listener each one takes.
 
 > **PluginFetchHeaders** = `Record`\<`string`, `string`\> \| `Headers` \| `Map`\<`string`, `string`\> \| `Iterable`\<\[`string`, `string`\], `void`, `undefined`\>
 
-Any header collection [fetch](#fetch) accepts — read structurally, not by class.
+Any header collection [fetch](#fetch-1) accepts — read structurally, not by class.
 
 #### Type Parameters
 
@@ -2375,7 +2454,7 @@ Any header collection [fetch](#fetch) accepts — read structurally, not by clas
 
 > **PluginFetchInit** = `object`
 
-Options for [fetch](#fetch) — a subset of `RequestInit` the host proxy supports.
+Options for [fetch](#fetch-1) — a subset of `RequestInit` the host proxy supports.
 
 #### Type Parameters
 

--- a/impro-plugin/main.d.ts
+++ b/impro-plugin/main.d.ts
@@ -229,6 +229,8 @@ export class App {
     currentUser: ProfileView | null;
     /** Read-only appview accessors — see {@link PluginData}. */
     data: PluginData;
+    /** A user-approved network address — see {@link CustomEndpoint}. */
+    customEndpoint: CustomEndpoint;
     /**
      * Register an event listener. Supported events:
      *
@@ -332,6 +334,47 @@ export class PluginResponse {
      */
     json(): Promise<unknown>;
     #private;
+}
+/**
+ * Lets a plugin talk to one network address a human has personally typed
+ * into its settings and approved — not a manifest-declared allowlist like
+ * {@link fetch}, and not "any address": {@link CustomEndpoint.requestUrl}
+ * always re-prompts the user with the exact address before it takes effect,
+ * and {@link CustomEndpoint.fetch} only ever succeeds against that one
+ * approved address. Unlike the manifest-gated {@link fetch}, non-`https:`
+ * addresses (e.g. a local Ollama server on `http://localhost:11434`) and an
+ * `Authorization` header are both allowed — it's the plugin's own
+ * credential for an address the user explicitly approved, not an ambient
+ * one being smuggled to an unreviewed third-party host. Requires the
+ * `"customEndpoint"` scope in the manifest's `permissions.network`.
+ */
+export class CustomEndpoint {
+    /**
+     * The currently-approved URL, or null if none has been approved yet (or
+     * it was cleared, e.g. by uninstalling and reinstalling the plugin).
+     * @returns {Promise<string | null>}
+     */
+    getUrl(): Promise<string | null>;
+    /**
+     * Prompts the user to approve `url` as this plugin's one allowed network
+     * address.
+     * @param {string} url
+     * @returns {Promise<{ accepted: boolean, url: string | null }>} `url` is
+     *   the *current* approved address (unchanged from before if declined);
+     *   `accepted` reflects whether this particular request was granted.
+     */
+    requestUrl(url: string): Promise<{
+        accepted: boolean;
+        url: string | null;
+    }>;
+    /**
+     * Fetches `url`, which must exactly match the currently-approved address
+     * (see {@link CustomEndpoint.requestUrl}) or this rejects.
+     * @param {string} url
+     * @param {PluginFetchInit} [init]
+     * @returns {Promise<PluginResponse>}
+     */
+    fetch(url: string, init?: PluginFetchInit): Promise<PluginResponse>;
 }
 /**
  * Shows a toast notification. `noticeEl` is a {@link VirtualEl} that can be

--- a/impro-plugin/main.js
+++ b/impro-plugin/main.js
@@ -375,6 +375,8 @@ export class App {
     this.currentUser = null;
     /** Read-only appview accessors — see {@link PluginData}. */
     this.data = new PluginData();
+    /** A user-approved network address — see {@link CustomEndpoint}. */
+    this.customEndpoint = new CustomEndpoint();
   }
   /**
    * Register an event listener. Supported events:
@@ -594,6 +596,61 @@ export class PluginResponse {
    */
   async json() {
     return JSON.parse(await this.text());
+  }
+}
+
+/**
+ * Lets a plugin talk to one network address a human has personally typed
+ * into its settings and approved — not a manifest-declared allowlist like
+ * {@link fetch}, and not "any address": {@link CustomEndpoint.requestUrl}
+ * always re-prompts the user with the exact address before it takes effect,
+ * and {@link CustomEndpoint.fetch} only ever succeeds against that one
+ * approved address. Unlike the manifest-gated {@link fetch}, non-`https:`
+ * addresses (e.g. a local Ollama server on `http://localhost:11434`) and an
+ * `Authorization` header are both allowed — it's the plugin's own
+ * credential for an address the user explicitly approved, not an ambient
+ * one being smuggled to an unreviewed third-party host. Requires the
+ * `"customEndpoint"` scope in the manifest's `permissions.network`.
+ */
+export class CustomEndpoint {
+  /**
+   * The currently-approved URL, or null if none has been approved yet (or
+   * it was cleared, e.g. by uninstalling and reinstalling the plugin).
+   * @returns {Promise<string | null>}
+   */
+  getUrl() {
+    return /** @type {Promise<string | null>} */ (
+      hostCall("getCustomEndpointUrl")
+    );
+  }
+  /**
+   * Prompts the user to approve `url` as this plugin's one allowed network
+   * address.
+   * @param {string} url
+   * @returns {Promise<{ accepted: boolean, url: string | null }>} `url` is
+   *   the *current* approved address (unchanged from before if declined);
+   *   `accepted` reflects whether this particular request was granted.
+   */
+  requestUrl(url) {
+    return /** @type {Promise<{ accepted: boolean, url: string | null }>} */ (
+      hostCall("requestCustomEndpointUrl", { url: String(url) })
+    );
+  }
+  /**
+   * Fetches `url`, which must exactly match the currently-approved address
+   * (see {@link CustomEndpoint.requestUrl}) or this rejects.
+   * @param {string} url
+   * @param {PluginFetchInit} [init]
+   * @returns {Promise<PluginResponse>}
+   */
+  async fetch(url, init = {}) {
+    const result = /** @type {SerializedFetchResponse} */ (
+      await hostCall("customEndpointFetch", {
+        url,
+        init: serializeFetchInit(init),
+      })
+    );
+    return new PluginResponse(result);
   }
 }
 

--- a/src/js/plugins/pluginCustomEndpointStore.js
+++ b/src/js/plugins/pluginCustomEndpointStore.js
@@ -1,0 +1,53 @@
+// Holds the one network address each plugin has been explicitly approved
+// to reach via app.customEndpoint (see impro-plugin/main.js's
+// CustomEndpoint and pluginService.js's requestCustomEndpointUrl/
+// customEndpointFetch host methods). Deliberately a separate store from
+// PluginLocalDataStore even though the underlying mechanism is the same
+// (device-local, unsynced localStorage): loadLocalData/saveLocalData hand a
+// plugin free read/write access to its own blob, and an approval a plugin
+// could silently rewrite itself would defeat the point of requiring a
+// human to approve it first. Sessions without a DID get a
+// PluginCustomEndpointMemoryStore instead, which lasts only for the
+// session — matching PluginMemoryDataStore's fallback.
+
+const KEY_PREFIX = "improPluginCustomEndpoint";
+
+export class PluginCustomEndpointStore {
+  constructor(did) {
+    this.did = did;
+  }
+
+  _key(pluginId) {
+    return `${KEY_PREFIX}:${this.did}:${pluginId}`;
+  }
+
+  get(pluginId) {
+    return localStorage.getItem(this._key(pluginId));
+  }
+
+  set(pluginId, url) {
+    localStorage.setItem(this._key(pluginId), url);
+  }
+
+  clear(pluginId) {
+    localStorage.removeItem(this._key(pluginId));
+  }
+}
+
+export class PluginCustomEndpointMemoryStore {
+  constructor() {
+    this._data = new Map();
+  }
+
+  get(pluginId) {
+    return this._data.get(pluginId) ?? null;
+  }
+
+  set(pluginId, url) {
+    this._data.set(pluginId, url);
+  }
+
+  clear(pluginId) {
+    this._data.delete(pluginId);
+  }
+}

--- a/src/js/plugins/pluginModal.js
+++ b/src/js/plugins/pluginModal.js
@@ -118,6 +118,11 @@ const ACTION_LABELS = {
     'Send feed feedback (e.g. "show fewer/more like this") on your behalf',
 };
 
+const NETWORK_LABELS = {
+  customEndpoint:
+    "Send requests to one address of your choosing, which you'll approve separately",
+};
+
 function permissionsSectionTemplate({ title, items }) {
   return html`
     <div class="permission-prompt-section">
@@ -146,6 +151,15 @@ function permissionsListTemplate({ permissions }) {
       permissionsSectionTemplate({
         title: "Act on your account:",
         items: actionScopes.map((scope) => ACTION_LABELS[scope] ?? scope),
+      }),
+    );
+  }
+  const networkScopes = permissions.network ?? [];
+  if (networkScopes.length > 0) {
+    sections.push(
+      permissionsSectionTemplate({
+        title: "Connect to an address you approve:",
+        items: networkScopes.map((scope) => NETWORK_LABELS[scope] ?? scope),
       }),
     );
   }
@@ -186,6 +200,30 @@ export async function showPluginUpdatePermissionsModal({
     {
       title: "Grant new permissions?",
       confirmButtonText: "Allow and update",
+    },
+  );
+}
+
+// Shown by requestCustomEndpointUrl (pluginService.js) every time a plugin
+// asks to approve a network address — not just once at install, since the
+// address itself (e.g. a local Ollama server's port) is something the user
+// picks per-plugin, not something a manifest could declare in advance.
+export async function showCustomEndpointApprovalModal({ pluginName, url }) {
+  const name = pluginName ?? "This plugin";
+  return confirmModal(
+    html`<span class="permission-prompt" data-testid="custom-endpoint-prompt">
+      <span class="permission-prompt-intro">${name} wants to connect to:</span>
+      <div class="permission-prompt-sections">
+        <div class="permission-prompt-section">
+          <ul class="permission-prompt-list">
+            <li><code>${url}</code></li>
+          </ul>
+        </div>
+      </div>
+    </span>`,
+    {
+      title: "Approve this address?",
+      confirmButtonText: "Approve",
     },
   );
 }

--- a/src/js/plugins/pluginPermissions.js
+++ b/src/js/plugins/pluginPermissions.js
@@ -1,6 +1,7 @@
 import { unique } from "/js/utils.js";
 
 const ACTION_SCOPES = ["mute", "block", "feedFeedback"];
+const NETWORK_SCOPES = ["customEndpoint"];
 
 export function getPermissionsFromManifest(manifest) {
   return parsePermissions(manifest.permissions ?? {});
@@ -26,6 +27,15 @@ export function parsePermissions(permissions) {
     );
     if (actionScopes.length > 0) parsed.actions = actionScopes;
   }
+  if (permissions.network) {
+    const networkArray = Array.isArray(permissions.network)
+      ? permissions.network
+      : [permissions.network];
+    const networkScopes = unique(
+      networkArray.filter((entry) => NETWORK_SCOPES.includes(entry)),
+    );
+    if (networkScopes.length > 0) parsed.network = networkScopes;
+  }
   return parsed;
 }
 
@@ -33,6 +43,11 @@ export function parsePermissions(permissions) {
 // like this" feed-interaction signal)
 export function isActionAllowed(action, permissions) {
   return (permissions.actions ?? []).includes(action);
+}
+
+// scope is one of NETWORK_SCOPES ("customEndpoint" today).
+export function isNetworkAllowed(scope, permissions) {
+  return (permissions.network ?? []).includes(scope);
 }
 
 export function diffPermissions(current, next) {

--- a/src/js/plugins/pluginRequests.js
+++ b/src/js/plugins/pluginRequests.js
@@ -2,7 +2,14 @@ import { isFetchAllowed } from "/js/plugins/pluginPermissions.js";
 
 const ALLOWED_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"];
 
-const FORBIDDEN_HEADERS = ["authorization", "cookie"];
+// Authorization is stripped from the ordinary manifest-allowlisted fetch()
+// (an ambient credential shouldn't be forwardable to any host a manifest
+// merely lists), but allowed through customEndpointFetch, where the target
+// is a single address a human explicitly typed in and approved - there it's
+// the plugin's own credential for a destination the user chose, not
+// something being smuggled to an unreviewed third party.
+const FETCH_FORBIDDEN_HEADERS = ["authorization", "cookie"];
+const CUSTOM_ENDPOINT_FORBIDDEN_HEADERS = ["cookie"];
 const MAX_BODY_CHARS = 1_000_000;
 export const MAX_RESPONSE_BYTES = 100_000_000;
 
@@ -15,8 +22,37 @@ export async function pluginFetch(
   if (!isFetchAllowed(url, permissions)) {
     throw new Error(`fetch to "${url}" not permitted`);
   }
+  return performSanitizedFetch(url, init, FETCH_FORBIDDEN_HEADERS, fetchImpl);
+}
+
+// approvedUrl is whatever the host currently has on file for this plugin
+// from a prior requestCustomEndpointUrl approval (see
+// pluginCustomEndpointStore.js) - url must match it exactly. Unlike
+// pluginFetch, there's no scheme restriction here: fetch() itself already
+// rejects schemes it doesn't support, and the browser's own mixed-content
+// rules (which always trust localhost/127.0.0.1 regardless of scheme) are
+// what make a plain http:// local Ollama server reachable from an https://
+// page in the first place - nothing here needs to special-case that.
+export async function customEndpointFetch(
+  approvedUrl,
+  url,
+  init,
+  fetchImpl = fetch.bind(globalThis),
+) {
+  if (approvedUrl == null || url !== approvedUrl) {
+    throw new Error(`"${url}" is not the approved custom endpoint`);
+  }
+  return performSanitizedFetch(
+    url,
+    init,
+    CUSTOM_ENDPOINT_FORBIDDEN_HEADERS,
+    fetchImpl,
+  );
+}
+
+async function performSanitizedFetch(url, init, forbiddenHeaders, fetchImpl) {
   const response = await fetchImpl(url, {
-    ...sanitizeFetchInit(init),
+    ...sanitizeFetchInit(init, forbiddenHeaders),
     credentials: "omit",
     redirect: "error",
     mode: "cors",
@@ -36,7 +72,7 @@ export async function pluginFetch(
   };
 }
 
-function sanitizeFetchInit(init) {
+function sanitizeFetchInit(init, forbiddenHeaders) {
   const safeInit = {};
   const method = (init?.method ?? "GET").toUpperCase();
   if (!ALLOWED_METHODS.includes(method)) {
@@ -46,7 +82,7 @@ function sanitizeFetchInit(init) {
   const headers = {};
   for (const [name, value] of Object.entries(init?.headers ?? {})) {
     const lowerName = String(name).toLowerCase();
-    if (FORBIDDEN_HEADERS.includes(lowerName)) {
+    if (forbiddenHeaders.includes(lowerName)) {
       throw new Error(`fetch header "${name}" not permitted`);
     }
     headers[name] = String(value);

--- a/src/js/plugins/pluginService.js
+++ b/src/js/plugins/pluginService.js
@@ -5,6 +5,7 @@ import {
   hidePluginModal,
   showPluginInstallPermissionsModal,
   showPluginUpdatePermissionsModal,
+  showCustomEndpointApprovalModal,
 } from "/js/plugins/pluginModal.js";
 import { showPluginToast, hidePluginToast, showToast } from "/js/toasts.js";
 import { PluginRenderer } from "/js/plugins/pluginRendering.js";
@@ -17,12 +18,19 @@ import {
   PluginLocalDataStore,
   PluginMemoryDataStore,
 } from "/js/plugins/pluginLocalDataStore.js";
+import {
+  PluginCustomEndpointStore,
+  PluginCustomEndpointMemoryStore,
+} from "/js/plugins/pluginCustomEndpointStore.js";
 import { PluginPreferencesManager } from "/js/plugins/pluginPreferencesManager.js";
 import { PluginRichTextDispatcher } from "/js/plugins/pluginRichTextDispatcher.js";
 import { PluginSlotDispatcher } from "/js/plugins/pluginSlotDispatcher.js";
 import { SourceProvider } from "/js/plugins/sourceProvider.js";
 import { PluginStylesLoader } from "/js/plugins/pluginStylesLoader.js";
-import { pluginFetch } from "/js/plugins/pluginRequests.js";
+import {
+  pluginFetch,
+  customEndpointFetch,
+} from "/js/plugins/pluginRequests.js";
 import { Slingshot } from "/js/slingshot.js";
 import {
   getPermissionsFromManifest,
@@ -30,6 +38,7 @@ import {
   diffPermissions,
   isEmptyPermissions,
   isActionAllowed,
+  isNetworkAllowed,
 } from "/js/plugins/pluginPermissions.js";
 import { compareVersions, groupBy, isDev, sortBy } from "/js/utils.js";
 import { Signal, SignalMap, SignalSet, ReactiveStore } from "/js/signals.js";
@@ -202,6 +211,9 @@ export class PluginService extends ReactiveStore {
     this.localDataStore = session?.did
       ? new PluginLocalDataStore(session.did)
       : new PluginMemoryDataStore();
+    this.customEndpointStore = session?.did
+      ? new PluginCustomEndpointStore(session.did)
+      : new PluginCustomEndpointMemoryStore();
     this.isPreviewMode = false;
     this._dataLayer = dataLayer;
     this._hiddenFeedItemsStore = hiddenFeedItemsStore;
@@ -400,6 +412,37 @@ export class PluginService extends ReactiveStore {
     this.pluginBridge.addHostMethod("saveLocalData", (plugin, { data }) => {
       this.localDataStore.set(plugin.pluginId, data);
     });
+
+    this.pluginBridge.addHostMethod("getCustomEndpointUrl", (plugin) => {
+      this._requireNetworkPermission(plugin, "customEndpoint");
+      return this.customEndpointStore.get(plugin.pluginId);
+    });
+
+    this.pluginBridge.addHostMethod(
+      "requestCustomEndpointUrl",
+      async (plugin, { url }) => {
+        this._requireNetworkPermission(plugin, "customEndpoint");
+        requireHostMethodArg("requestCustomEndpointUrl", "url", url);
+        const accepted = await showCustomEndpointApprovalModal({
+          pluginName: plugin.manifest?.name,
+          url,
+        });
+        if (accepted) this.customEndpointStore.set(plugin.pluginId, url);
+        return {
+          accepted,
+          url: this.customEndpointStore.get(plugin.pluginId),
+        };
+      },
+    );
+
+    this.pluginBridge.addHostMethod(
+      "customEndpointFetch",
+      (plugin, { url, init }) => {
+        this._requireNetworkPermission(plugin, "customEndpoint");
+        const approvedUrl = this.customEndpointStore.get(plugin.pluginId);
+        return customEndpointFetch(approvedUrl, url, init);
+      },
+    );
 
     this.pluginBridge.addHostMethod(
       "refreshSettingTab",
@@ -634,6 +677,15 @@ export class PluginService extends ReactiveStore {
     if (!isActionAllowed(action, permissions)) {
       throw new Error(
         `"${plugin.pluginId}" does not have "${action}" action permission`,
+      );
+    }
+  }
+
+  _requireNetworkPermission(plugin, scope) {
+    const permissions = this._getPermissionsForPlugin(plugin.pluginId);
+    if (!isNetworkAllowed(scope, permissions)) {
+      throw new Error(
+        `"${plugin.pluginId}" does not have "${scope}" network permission`,
       );
     }
   }
@@ -933,6 +985,7 @@ export class PluginService extends ReactiveStore {
     await this.prefManager.removeInstalledPlugin(pluginId);
     await this.prefManager.clearSettingsForPlugin(pluginId);
     this.localDataStore.clear(pluginId);
+    this.customEndpointStore.clear(pluginId);
     await this._reconcileCache(this.prefManager.$installedPlugins.get());
   }
 

--- a/tests/unit/specs/plugins/pluginCustomEndpointStore.test.js
+++ b/tests/unit/specs/plugins/pluginCustomEndpointStore.test.js
@@ -1,0 +1,59 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  PluginCustomEndpointStore,
+  PluginCustomEndpointMemoryStore,
+} from "/js/plugins/pluginCustomEndpointStore.js";
+
+const DID_ONE = "did:plc:user-one";
+const DID_TWO = "did:plc:user-two";
+
+describe("PluginCustomEndpointStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns null when nothing has been approved", () => {
+    const store = new PluginCustomEndpointStore(DID_ONE);
+    assert.deepEqual(store.get("plugin-a"), null);
+  });
+
+  it("round-trips an approved URL", () => {
+    const store = new PluginCustomEndpointStore(DID_ONE);
+    store.set("plugin-a", "http://localhost:11434/api/chat");
+    assert.deepEqual(store.get("plugin-a"), "http://localhost:11434/api/chat");
+  });
+
+  it("isolates approvals between plugin ids", () => {
+    const store = new PluginCustomEndpointStore(DID_ONE);
+    store.set("plugin-a", "http://localhost:11434/x");
+    store.set("plugin-b", "http://localhost:8080/y");
+    assert.deepEqual(store.get("plugin-a"), "http://localhost:11434/x");
+    assert.deepEqual(store.get("plugin-b"), "http://localhost:8080/y");
+  });
+
+  it("isolates approvals between account dids", () => {
+    const storeOne = new PluginCustomEndpointStore(DID_ONE);
+    const storeTwo = new PluginCustomEndpointStore(DID_TWO);
+    storeOne.set("plugin-a", "http://localhost:11434/x");
+    assert.deepEqual(storeTwo.get("plugin-a"), null);
+  });
+
+  it("clear removes the approval", () => {
+    const store = new PluginCustomEndpointStore(DID_ONE);
+    store.set("plugin-a", "http://localhost:11434/x");
+    store.clear("plugin-a");
+    assert.deepEqual(store.get("plugin-a"), null);
+  });
+});
+
+describe("PluginCustomEndpointMemoryStore", () => {
+  it("round-trips within a session without touching localStorage", () => {
+    const store = new PluginCustomEndpointMemoryStore();
+    assert.deepEqual(store.get("plugin-a"), null);
+    store.set("plugin-a", "http://localhost:11434/x");
+    assert.deepEqual(store.get("plugin-a"), "http://localhost:11434/x");
+    store.clear("plugin-a");
+    assert.deepEqual(store.get("plugin-a"), null);
+  });
+});

--- a/tests/unit/specs/plugins/pluginPermissions.test.js
+++ b/tests/unit/specs/plugins/pluginPermissions.test.js
@@ -6,6 +6,7 @@ import {
   isEmptyPermissions,
   isFetchAllowed,
   isActionAllowed,
+  isNetworkAllowed,
 } from "/js/plugins/pluginPermissions.js";
 
 describe("parsePermissions", () => {
@@ -61,6 +62,24 @@ describe("parsePermissions", () => {
     assert.deepEqual(parsePermissions({ actions: [] }), {});
     assert.deepEqual(parsePermissions({ actions: ["feedback"] }), {});
   });
+
+  it("parses the customEndpoint network scope and drops unknown ones", () => {
+    assert.deepEqual(
+      parsePermissions({ network: ["customEndpoint", "anyHost"] }),
+      { network: ["customEndpoint"] },
+    );
+  });
+
+  it("wraps a string network value into an array", () => {
+    assert.deepEqual(parsePermissions({ network: "customEndpoint" }), {
+      network: ["customEndpoint"],
+    });
+  });
+
+  it("omits the network key when no valid scopes remain", () => {
+    assert.deepEqual(parsePermissions({ network: [] }), {});
+    assert.deepEqual(parsePermissions({ network: ["anyHost"] }), {});
+  });
 });
 
 describe("isActionAllowed", () => {
@@ -73,6 +92,13 @@ describe("isActionAllowed", () => {
 
   it("denies everything when the actions key is missing", () => {
     assert(!isActionAllowed("mute", {}));
+  });
+});
+
+describe("isNetworkAllowed", () => {
+  it("allows only granted network scopes", () => {
+    assert(isNetworkAllowed("customEndpoint", { network: ["customEndpoint"] }));
+    assert(!isNetworkAllowed("customEndpoint", {}));
   });
 });
 

--- a/tests/unit/specs/plugins/pluginService.test.js
+++ b/tests/unit/specs/plugins/pluginService.test.js
@@ -2311,6 +2311,146 @@ describe("loadLocalData/saveLocalData host methods", () => {
   });
 });
 
+describe("customEndpoint host methods", () => {
+  function makeServiceWithPermissions(permissions, manifestName = "Translate") {
+    const { state, provider } = makeProvider();
+    state.installedPlugins = [
+      { id: "translate", version: "1.0.0", enabled: true, permissions },
+    ];
+    const service = makeServiceWithRealBridge({ provider });
+    const plugin = {
+      pluginId: "translate",
+      manifest: { name: manifestName },
+    };
+    return { service, plugin };
+  }
+
+  function getHandler(service, name) {
+    return service.pluginBridge._hostCallHandlers.get(name);
+  }
+
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function stubFetch(handler) {
+    const calls = [];
+    globalThis.fetch = async (url, init) => {
+      calls.push({ url, init });
+      return handler(url, init);
+    };
+    return { calls };
+  }
+
+  function jsonResponse(status, body) {
+    return {
+      status,
+      ok: status >= 200 && status < 300,
+      headers: {
+        get: (name) => (name === "content-type" ? "application/json" : null),
+      },
+      arrayBuffer: async () =>
+        new TextEncoder().encode(JSON.stringify(body)).buffer,
+    };
+  }
+
+  it("rejects every operation without the customEndpoint network scope", async () => {
+    const { service, plugin } = makeServiceWithPermissions({});
+    // getCustomEndpointUrl's handler is synchronous (unlike the other two),
+    // so it throws directly rather than returning a rejected promise.
+    assert.throws(
+      () => getHandler(service, "getCustomEndpointUrl")(plugin),
+      /"customEndpoint" network permission/,
+    );
+    await assert.rejects(
+      () =>
+        getHandler(service, "requestCustomEndpointUrl")(plugin, {
+          url: "http://localhost:11434/api/chat",
+        }),
+      /"customEndpoint" network permission/,
+    );
+    // customEndpointFetch's handler is also synchronous (it throws before
+    // ever reaching the customEndpointFetch() call that returns a promise).
+    assert.throws(
+      () =>
+        getHandler(service, "customEndpointFetch")(plugin, {
+          url: "http://localhost:11434/api/chat",
+          init: {},
+        }),
+      /"customEndpoint" network permission/,
+    );
+  });
+
+  it("returns null before anything has been approved", () => {
+    const { service, plugin } = makeServiceWithPermissions({
+      network: ["customEndpoint"],
+    });
+    assert.deepEqual(getHandler(service, "getCustomEndpointUrl")(plugin), null);
+  });
+
+  it("stores the URL and shows the plugin's name when approved", async () => {
+    const { service, plugin } = makeServiceWithPermissions(
+      { network: ["customEndpoint"] },
+      "Local Translate",
+    );
+    const requesting = getHandler(service, "requestCustomEndpointUrl")(plugin, {
+      url: "http://localhost:11434/api/chat",
+    });
+    await respondToConfirm(true);
+    const result = await requesting;
+    assert.deepEqual(result, {
+      accepted: true,
+      url: "http://localhost:11434/api/chat",
+    });
+    assert.deepEqual(
+      getHandler(service, "getCustomEndpointUrl")(plugin),
+      "http://localhost:11434/api/chat",
+    );
+  });
+
+  it("does not store the URL when declined", async () => {
+    const { service, plugin } = makeServiceWithPermissions({
+      network: ["customEndpoint"],
+    });
+    const requesting = getHandler(service, "requestCustomEndpointUrl")(plugin, {
+      url: "http://localhost:11434/api/chat",
+    });
+    await respondToConfirm(false);
+    const result = await requesting;
+    assert.deepEqual(result, { accepted: false, url: null });
+    assert.deepEqual(getHandler(service, "getCustomEndpointUrl")(plugin), null);
+  });
+
+  it("fetches only the exact approved URL", async () => {
+    const { service, plugin } = makeServiceWithPermissions({
+      network: ["customEndpoint"],
+    });
+    const requesting = getHandler(service, "requestCustomEndpointUrl")(plugin, {
+      url: "http://localhost:11434/api/chat",
+    });
+    await respondToConfirm(true);
+    await requesting;
+
+    const { calls } = stubFetch(async () => jsonResponse(200, { ok: true }));
+    const result = await getHandler(service, "customEndpointFetch")(plugin, {
+      url: "http://localhost:11434/api/chat",
+      init: { method: "POST", headers: { Authorization: "Bearer key" } },
+    });
+    assert.deepEqual(result.status, 200);
+    assert.deepEqual(calls[0].init.headers.Authorization, "Bearer key");
+
+    await assert.rejects(
+      () =>
+        getHandler(service, "customEndpointFetch")(plugin, {
+          url: "http://other-host/x",
+          init: {},
+        }),
+      /not the approved custom endpoint/,
+    );
+  });
+});
+
 describe("getPostComposerInit", () => {
   function addListener(service, pluginId, handler) {
     let listeners = service.registries.eventListeners.get("post-composer-open");


### PR DESCRIPTION
> **Note on authorship:** this PR description was drafted by Claude (Anthropic's AI coding assistant), working with the account holder across the design, implementation, and testing of these changes. It's posted here under their GitHub account since that's how `gh`/GitHub PRs work, but the analysis and writing below is Claude's, reviewed and submitted by the human. Flagging this upfront rather than letting it read as 100% human-authored.

## Summary

Split out from #41 at [@kindgracekind's request](https://github.com/improsocial/impro/pull/41#issuecomment-5262558666), as independent functionality not specific to the local-WASM-translation work that motivated it.

**Branched from #44's branch** (the binary-safe `fetch()` fix), not from `main` directly — this shares its `bytesToBase64`/`base64ToArrayBuffer` helpers and rewritten `PluginResponse`, since custom-endpoint fetch responses move across the same base64-over-`postMessage` boundary. GitHub doesn't support setting a PR's base to a branch that only exists on a fork, so this PR's base is `main` like normal, which means the diff below currently includes #44's commit too — it'll automatically narrow to just this PR's own commit once #44 merges.

## Why

`kindgracekind` asked on #41: *"For 5, I think we can allow local plugins to make http fetches (with a warning) - would that solve for your use case?"*

Not quite, for two separate reasons:

1. **`http:` isn't the only gap.** The existing `permissions.fetch` allowlist requires a manifest-declared *fixed host* — that structurally can't express "whatever port the user's local Ollama happens to be on," even over `https:`. It needs to be a runtime-approved address, not a manifest-time one.
2. **Avoiding pre-baked cloud hosts was actually the point.** The first draft of this tried adding explicit manifest grants for OpenAI's and Anthropic's endpoints specifically — which looked wrong for a plugin that calls itself "local" to be asking permission for at install time, before the user has done anything. `app.customEndpoint` asks for one generic grant ("connect to an address you'll approve"), and *that* one address can be a local Ollama/LM Studio server, or the official API of any cloud provider, or anything else — the plugin never has to enumerate hosts in its manifest at all.

## The change

- New SDK surface `app.customEndpoint` (`impro-plugin/main.js`): `getUrl()`, `requestUrl(url)` (shows a host confirmation modal naming the plugin and the exact address; always re-prompts before a *change* takes effect), and `fetch(url, init)` (succeeds only against the currently-approved address).
- Unlike the manifest-gated `fetch()`, this path doesn't force `https:` (mixed-content rules already trust `localhost`/`127.0.0.1` regardless of scheme, so nothing here needs to special-case that) and **does** allow an `Authorization` header through — it's the plugin's own credential for an address a human explicitly typed in and approved, not an ambient one being smuggled to whatever a manifest merely lists.
- Still strips `cookie`, still `credentials: "omit"`, still no redirect follow — the relaxation is scoped to scheme + `Authorization` only.
- New manifest permission scope `permissions.network: ["customEndpoint"]`, surfaced in the install/update permissions modal like every other scope.
- Approval storage (`pluginCustomEndpointStore.js`) is a separate store from `loadLocalData`/`saveLocalData` on purpose: those hand a plugin free read/write access to its own blob, and an approval a plugin could silently rewrite itself would defeat the point of requiring a human to approve it first. Cleared on uninstall.

Designed fresh for this PR — not ported from this fork's own unmerged `plugin-overlay-companion-api` branch, though the shape of the problem (propose one URL, a human approves that exact URL) only really has one sane solution.

## Testing

Full existing unit suite passes unmodified; new `pluginCustomEndpointStore.test.js`, plus coverage in `pluginService.test.js` for the approval flow (grant/decline/re-approval, exact-URL matching, `Authorization` header handling) and `pluginPermissions.test.js` for the new scope.
