### PR TITLE
Say how a service resolves user DIDs

### DIFF
--- a/specs/bsky-push-notification-service.md
+++ b/specs/bsky-push-notification-service.md
@@ -34,16 +34,9 @@ from the browser.
 
 ## User identity resolution
 
-A service resolves user DIDs in two places this document requires: the
+A service resolves user DIDs in two places: the
 service-auth `iss` on device registration, and `login_hint` in the auth
 handoff. Both MUST accept `did:plc` and `did:web`.
-
-`did:web` user DIDs are hostname-only — no path segments, and ports
-only for `localhost` in development — and resolve from
-`https://<hostname>/.well-known/did.json`, not from the PLC directory.
-A service that resolves every DID through the PLC directory does not
-degrade for self-hosted accounts; it excludes them, since both the
-registration signature check and the handoff's PDS lookup fail.
 
 ## Config document
 
@@ -89,8 +82,7 @@ browser to it and receives it back:
 1. The client navigates to `authUrl` with query parameters:
    - `login_hint` — the user's handle or DID. A service that accepts
      a handle MUST resolve it to a DID, and MUST verify the resolved
-     document's `alsoKnownAs` claims that handle, before treating it
-     as the hinted DID in step 3.
+     document's `alsoKnownAs` claims that handle.
    - `return_url` — where to redirect when done
    - `chat_previews` — `1` or `0`; whether the grant should include
      the message-content scope (see "Grant tiers")
@@ -230,7 +222,7 @@ notifications can trigger browsers' abusive-notification checks.
 - Verify `sub` against `login_hint` in the auth callback.
 - The service-auth `iss` and the handoff's `login_hint` are both
   caller-controlled and unauthenticated — `iss` selects the key before
-  any signature is checked. A service MUST NOT let either direct a
+  any signature is checked. A service MUST NOT let either value direct a
   document fetch at a private address: reject IP literals and reserved
   names, and do not follow redirects when fetching a `did:web`
   document.

--- a/specs/bsky-push-notification-service.md
+++ b/specs/bsky-push-notification-service.md
@@ -1,6 +1,6 @@
 # Bluesky Push Notification Service Spec
 
-#### Version: 0.0.2
+#### Version: 0.0.3
 
 The normative interface between a Bluesky client (an app built on the
 `app.bsky.*` appview and `chat.bsky.*` chat services) and a push
@@ -31,6 +31,19 @@ publish the entry works. Everything below is served from the
 A `did:web` document MUST be served with permissive CORS,
 (`Access-Control-Allow-Origin: *`) — clients fetch it cross-origin
 from the browser.
+
+## User identity resolution
+
+A service resolves user DIDs in two places this document requires: the
+service-auth `iss` on device registration, and `login_hint` in the auth
+handoff. Both MUST accept `did:plc` and `did:web`.
+
+`did:web` user DIDs are hostname-only — no path segments, and ports
+only for `localhost` in development — and resolve from
+`https://<hostname>/.well-known/did.json`, not from the PLC directory.
+A service that resolves every DID through the PLC directory does not
+degrade for self-hosted accounts; it excludes them, since both the
+registration signature check and the handoff's PDS lookup fail.
 
 ## Config document
 
@@ -74,7 +87,10 @@ is its own OAuth client against the user's PDS; the client hands the
 browser to it and receives it back:
 
 1. The client navigates to `authUrl` with query parameters:
-   - `login_hint` — the user's handle or DID
+   - `login_hint` — the user's handle or DID. A service that accepts
+     a handle MUST resolve it to a DID, and MUST verify the resolved
+     document's `alsoKnownAs` claims that handle, before treating it
+     as the hinted DID in step 3.
    - `return_url` — where to redirect when done
    - `chat_previews` — `1` or `0`; whether the grant should include
      the message-content scope (see "Grant tiers")
@@ -212,6 +228,12 @@ notifications can trigger browsers' abusive-notification checks.
   check, a JWT minted for another notification service is replayable
   here.
 - Verify `sub` against `login_hint` in the auth callback.
+- The service-auth `iss` and the handoff's `login_hint` are both
+  caller-controlled and unauthenticated — `iss` selects the key before
+  any signature is checked. A service MUST NOT let either direct a
+  document fetch at a private address: reject IP literals and reserved
+  names, and do not follow redirects when fetching a `did:web`
+  document.
 - Grants are read-only by scope; the previews tier can read chat
   message content and clients must disclose that at consent.
 - Web Push payload encryption is mandatory (RFC 8291) and is doing


### PR DESCRIPTION
Claude here, writing on 7778777's behalf — they prompted me to raise this
upstream after it broke their deployment, but the wording below is mine, so
argue with me and not with them.

The courier instance behind impro's push notifications logged this:

```
could not resolve a handle for did:web:vt3e.cat:
DID directory returned 404 Not Found for did:web:vt3e.cat
```

It had been resolving every user DID through `PLC_DIRECTORY_URL`. That works
until somebody self-hosts, and `plc.directory` has never heard of them.

**The gap:** this document specifies the *service's* DID carefully — "`did:web`
on the service's own origin is the expected common case" — and never says how
to resolve a *user's*, which it requires in two places: the service-auth `iss`
("`iss` is the user DID") and `login_hint`. Read together, the asymmetry
suggests `did:web` is the service-side method and `did:plc` the user-side one.
I wrote a PLC-only resolver from this document and did not notice.

What it costs is worse than the log line suggests. That line is the cosmetic
path — a chat preview attributing a message to "Someone". The same resolver
backs the signature check that is the *only* authentication on `registerPush`,
and the PDS lookup that begins the auth handoff. A self-hosted account is not
degraded, it is excluded: it cannot register a device and cannot grant.

Three changes, all as requirements rather than rationale:

1. **A `User identity resolution` section.** Both methods MUST resolve;
   `did:web` is hostname-only per atproto's DID spec and comes from the
   identity's own origin.

2. **`login_hint`'s handle form.** The document allows "handle or DID" but
   then requires verifying `sub` against "the hinted DID" — when a handle
   arrives there is no hinted DID, so a MUST-level security requirement has an
   unspecified precondition. Spelled out as resolve-then-verify-bidirectionally.

   If you would rather go the other way and just say `login_hint` MUST be a
   DID, that is a smaller surface and matches what impro actually sends
   (`courierPushService.js` passes `session.did`). Happy to swap it.

3. **A security bullet.** Once `did:web` is required, the document is asking
   implementers to fetch a URL chosen by an unauthenticated caller — `iss` is
   read *before* its signature is checked, `login_hint` is a query parameter.
   Worth naming, since the obvious implementation points at loopback.

Implementation is done and deployed on our side; this PR is only the document,
and nothing here depends on our code landing anywhere.

I tried to keep this to requirements, having learned from #43 that the war
stories belong in the PR body rather than the spec. If any of it is better left
unspecified, close it — the same call you made on #43, and it is your document.